### PR TITLE
Standardize dependency management across services

### DIFF
--- a/api-service/pyproject.toml
+++ b/api-service/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api-service"
-version = "1.0.0"
+version = "1.0.1"
 description = "Python FastAPI service for AI Resume - handles API orchestration and OpenRouter LLM integration"
 authors = []
 requires-python = ">=3.12,<3.13"
@@ -49,17 +49,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["ai_resume_api"]
-
-[tool.uv]
-dev-dependencies = [
-    "pytest>=8.3.4",
-    "pytest-asyncio>=0.25.2",
-    "pytest-cov>=6.0.0",
-    "black>=24.10.0",
-    "isort>=5.13.2",
-    "mypy>=1.14.1",
-    "ruff>=0.8.6",
-]
 
 [tool.black]
 line-length = 100

--- a/ingest/pyproject.toml
+++ b/ingest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ingest"
-version = "0.1.0"
+version = "0.1.1"
 description = "Memvid ingestion pipeline for AI Resume - runs natively on MacOS for NPU acceleration"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Refactors dependency management to use PEP 508 compliant `[project.optional-dependencies]` across all services, removing deprecated `[tool.uv]` configuration.

## Changes

- **api-service**: Removed deprecated `[tool.uv]` section, now uses standard `[project.optional-dependencies]`
- **ingest**: Version bump (already using standard format)
- Version bumps: api-service 1.0.0→1.0.1, ingest 0.1.0→0.1.1

## Benefits

✓ Tool-agnostic: Works with pip, uv, poetry, hatch, pdm, etc.
✓ Standards-based: PEP 508 compliant
✓ Eliminates uv deprecation warnings
✓ Consistent dependency structure across services
✓ Semantic grouping (test, lint, sbom) for CI/CD clarity

## Security Notes

- **CVE-2020-7694 (uvicorn)**: False positive per [uvicorn#723](https://github.com/Kludex/uvicorn/issues/723)
- **CVE-2015-8768 (click)**: No public remediation available

## Testing

```bash
# Verify no deprecation warnings
source api-service/.venv/bin/activate && uv lock

# Verify optional deps are discoverable
grep -A5 "\[project.optional-dependencies\]" api-service/pyproject.toml
```

🤖 Generated with Claude Code