### PR TITLE
security: Use secrets module for session/trace IDs (GH_CODE_SCAN_4)

### DIFF
--- a/api-service/ai_resume_api/models.py
+++ b/api-service/ai_resume_api/models.py
@@ -2,9 +2,15 @@
 
 from datetime import datetime, timezone
 from typing import Literal
-from uuid import UUID, uuid4
+from uuid import UUID
+import secrets
 
 from pydantic import BaseModel, Field
+
+
+def generate_secure_session_id() -> UUID:
+    """Generate cryptographically secure session ID using secrets module."""
+    return UUID(bytes=secrets.token_bytes(16))
 
 # =============================================================================
 # Chat API Models
@@ -49,7 +55,7 @@ class ChatStreamEvent(BaseModel):
 class ChatResponse(BaseModel):
     """Non-streaming chat response."""
 
-    session_id: UUID = Field(default_factory=uuid4)
+    session_id: UUID = Field(default_factory=generate_secure_session_id)
     message: str = Field(..., description="Assistant response")
     chunks_retrieved: int = Field(..., description="Number of context chunks used")
     tokens_used: int = Field(..., description="Total tokens used")
@@ -213,7 +219,7 @@ class MemvidHealthResponse(BaseModel):
 class Session(BaseModel):
     """A chat session with conversation history."""
 
-    id: UUID = Field(default_factory=uuid4)
+    id: UUID = Field(default_factory=generate_secure_session_id)
     messages: list[ChatMessage] = Field(default_factory=list)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     last_activity: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/api-service/ai_resume_api/observability.py
+++ b/api-service/ai_resume_api/observability.py
@@ -7,7 +7,7 @@ This module provides:
 """
 
 import time
-import uuid
+import secrets
 from contextvars import ContextVar
 from dataclasses import dataclass
 
@@ -25,8 +25,8 @@ trace_id_ctx: ContextVar[str] = ContextVar("trace_id", default="")
 
 
 def generate_trace_id() -> str:
-    """Generate a new trace ID (UUID4 hex, 32 chars)."""
-    return uuid.uuid4().hex
+    """Generate cryptographically secure trace ID for request tracking."""
+    return secrets.token_hex(16)  # 32 hex chars, same format as uuid4().hex
 
 
 def get_trace_id() -> str:


### PR DESCRIPTION
## Summary

Replace `uuid.uuid4()` with cryptographically secure random generation using the `secrets` module for session IDs and trace IDs.

## Security Impact

**Fixes:** https://github.com/schwichtgit/ai-resume/security/code-scanning/4

- Eliminates predictable session ID generation
- Prevents session hijacking via ID prediction attacks
- Uses CSPRNG (cryptographically secure pseudorandom number generator)

## Changes

- **Session IDs:** `UUID(bytes=secrets.token_bytes(16))` instead of `uuid4()`
- **Trace IDs:** `secrets.token_hex(16)` instead of `uuid4().hex`
- **Helper function:** Added `generate_secure_session_id()` for session ID generation

## Testing

- [x] All 253 api-service tests pass
- [x] Session IDs maintain UUID format (backward compatible)
- [x] Trace IDs maintain 32-char hex format (backward compatible)
- [x] No breaking changes to API responses

## Test Plan

```bash
cd api-service
source .venv/bin/activate
pytest -v  # Expected: 253 tests pass
```

## Note

One pre-existing test warning exists (test_streaming_with_client_cancellation) - this is unrelated to this security fix and will be addressed separately.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)