### PR TITLE
fix(scripts): Replace unsafe ((VAR++)) arithmetic in test script

### DIFF
--- a/scripts/test-e2e-mock-gates.sh
+++ b/scripts/test-e2e-mock-gates.sh
@@ -32,16 +32,16 @@ print_test() {
 
 print_pass() {
     echo -e "${GREEN}✓ PASS: $1${NC}"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 }
 
 print_fail() {
     echo -e "${RED}✗ FAIL: $1${NC}"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 }
 
 run_test() {
-    ((TESTS_RUN++))
+    TESTS_RUN=$((TESTS_RUN + 1))
     print_test "$1"
 }
 


### PR DESCRIPTION
## Summary

- Fix bash arithmetic bug in `scripts/test-e2e-mock-gates.sh` where `((VAR++))` expressions abort the script under `set -euo pipefail` when the variable is 0, because `((0++))` evaluates to falsy (exit code 1)
- Replace all three instances (`TESTS_RUN++`, `TESTS_PASSED++`, `TESTS_FAILED++`) with the safe form `VAR=$((VAR + 1))` which always returns exit code 0

## Test plan

- [ ] Run `bash -n scripts/test-e2e-mock-gates.sh` to confirm syntax validity (done locally, passes)
- [ ] Run the test script end-to-end to verify counters increment correctly and the script no longer aborts on the first `run_test` call