### PR TITLE
fix(ci): resolve release validate race condition with CI re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,54 +45,74 @@ jobs:
         id: ci
         run: |
           SHA="${{ github.sha }}"
-          echo "Waiting for CI to complete on commit ${SHA}..."
+          TAG_NAME="${{ github.ref_name }}"
+          REPO="${{ github.repository }}"
+          echo "Waiting for CI to pass on commit ${SHA}..."
 
           MAX_WAIT=1800  # 30 minutes
           POLL_INTERVAL=30
           ELAPSED=0
 
-          TAG_NAME="${{ github.ref_name }}"
+          # check_run: given a run ID, verify it has successful container
+          # builds AND a successful summary job. Prints "pass" on success.
+          check_run() {
+            local rid=$1
+            local conclusion
+            conclusion=$(gh api "repos/${REPO}/actions/runs/${rid}" --jq '.conclusion')
+            if [ "$conclusion" != "success" ]; then
+              return
+            fi
+            local build_jobs
+            build_jobs=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs?per_page=100" \
+              --jq '[.jobs[] | select(.name | startswith("container-build")) | select(.conclusion == "success")] | length')
+            if [ "$build_jobs" -eq 0 ]; then
+              return
+            fi
+            local summary
+            summary=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs?per_page=100" \
+              --jq '.jobs[] | select(.name == "summary") | .conclusion')
+            if [ "$summary" = "success" ]; then
+              echo "pass"
+            fi
+          }
 
+          # has_in_progress: check if any CI run for this SHA is still running
+          # (e.g. a re-run). Returns "yes" if so.
+          has_in_progress() {
+            local count
+            count=$(gh api "repos/${REPO}/actions/workflows/ci.yml/runs?head_sha=${SHA}" \
+              --jq '[.workflow_runs[] | select(.status != "completed")] | length')
+            if [ "$count" -gt 0 ]; then
+              echo "yes"
+            fi
+          }
+
+          RUN_ID=""
           while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
-            # Prefer the tag-triggered CI run over a main-push run that shares
-            # the same SHA. The tag-triggered run builds images with versioned
-            # tags (v1.0.0.amd64), while the main-push run uses dev-* tags.
-            # When both exist, the main-push run often completes first and would
-            # be selected incorrectly without this filter.
-            FOUND=""
-            for RUN_ID in $(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=${SHA}&status=completed" \
-              --jq ".workflow_runs[] | select(.head_branch == \"${TAG_NAME}\") | .id"); do
-
-              BUILD_JOBS=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" \
-                --jq '[.jobs[] | select(.name | startswith("container-build")) | select(.conclusion == "success")] | length')
-
-              if [ "$BUILD_JOBS" -gt 0 ]; then
-                echo "Found tag-triggered CI run ${RUN_ID} with ${BUILD_JOBS} successful container-build jobs"
-                FOUND=1
-                break
-              else
-                echo "CI run ${RUN_ID} has no successful container-build jobs, skipping..."
+            # Fetch all CI runs for this commit (completed or not), newest first.
+            # Prefer tag-triggered runs over main-push runs.
+            for rid in $(gh api "repos/${REPO}/actions/workflows/ci.yml/runs?head_sha=${SHA}" \
+              --jq "[.workflow_runs[] | select(.head_branch == \"${TAG_NAME}\")] | sort_by(.run_started_at) | reverse | .[].id"); do
+              if [ "$(check_run "$rid")" = "pass" ]; then
+                RUN_ID="$rid"
+                break 2
               fi
             done
 
-            # Fallback: if no tag-triggered run found, accept any run with builds
-            if [ -z "$FOUND" ]; then
-              for RUN_ID in $(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=${SHA}&status=completed" \
-                --jq '.workflow_runs[].id'); do
+            # Fallback: accept any run for this SHA
+            for rid in $(gh api "repos/${REPO}/actions/workflows/ci.yml/runs?head_sha=${SHA}" \
+              --jq '.workflow_runs | sort_by(.run_started_at) | reverse | .[].id'); do
+              if [ "$(check_run "$rid")" = "pass" ]; then
+                RUN_ID="$rid"
+                echo "::warning::No tag-triggered CI run passed, using run ${rid}"
+                break 2
+              fi
+            done
 
-                BUILD_JOBS=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" \
-                  --jq '[.jobs[] | select(.name | startswith("container-build")) | select(.conclusion == "success")] | length')
-
-                if [ "$BUILD_JOBS" -gt 0 ]; then
-                  echo "::warning::No tag-triggered CI run found, using run ${RUN_ID} with ${BUILD_JOBS} successful container-build jobs"
-                  FOUND=1
-                  break
-                fi
-              done
-            fi
-
-            if [ -n "$FOUND" ]; then
-              break
+            # If no runs are still in progress, no point waiting further
+            if [ "$(has_in_progress)" != "yes" ]; then
+              echo "::error::All CI runs for ${SHA} have completed without passing"
+              exit 1
             fi
 
             echo "CI not ready yet (${ELAPSED}s elapsed), polling in ${POLL_INTERVAL}s..."
@@ -100,22 +120,12 @@ jobs:
             ELAPSED=$((ELAPSED + POLL_INTERVAL))
           done
 
-          if [ -z "$RUN_ID" ] || [ "$BUILD_JOBS" -eq 0 ]; then
-            echo "::error::CI did not complete within ${MAX_WAIT}s for commit ${SHA}"
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::CI did not pass within ${MAX_WAIT}s for commit ${SHA}"
             exit 1
           fi
 
-          # Check that the summary job concluded with success
-          SUMMARY_CONCLUSION=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" \
-            --jq '.jobs[] | select(.name == "summary") | .conclusion')
-
-          if [ "$SUMMARY_CONCLUSION" != "success" ]; then
-            echo "::error::CI has not passed on commit ${SHA}"
-            echo "Summary job conclusion: ${SUMMARY_CONCLUSION:-not found}"
-            exit 1
-          fi
-
-          echo "CI passed (run ${RUN_ID}, summary: ${SUMMARY_CONCLUSION})"
+          echo "CI passed (run ${RUN_ID})"
           echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
 
       - name: Validate changelog entry


### PR DESCRIPTION
## Summary
- Release validate job had a race condition where it picked up stale/failed CI runs instead of waiting for in-progress re-runs
- Root cause: queried only `status=completed` runs, took the first match, and checked summary job conclusion outside the poll loop
- Fix: query all runs sorted by `run_started_at` desc, require both `conclusion=success` on the run and `summary` job inside the selection loop, keep polling while any run is in-progress

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, re-tag `v0.1.0-alpha.12` and verify release workflow waits correctly for CI