### PR TITLE
fix(security): bump rustls-webpki 0.103.12 + rand 0.9.3

### DIFF
--- a/memvid-service/Cargo.lock
+++ b/memvid-service/Cargo.lock
@@ -2503,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/memvid-service/Cargo.lock
+++ b/memvid-service/Cargo.lock
@@ -151,7 +151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84790c55b5704b0d35130bf16a4ce22a8e70eb0ea773522557524d9a4852663d"
 dependencies = [
  "nix",
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]
@@ -1505,7 +1505,7 @@ dependencies = [
  "md-5",
  "nom 8.0.0",
  "nom_locate",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rangemap",
  "sha2",
  "stringprep",
@@ -1535,7 +1535,7 @@ dependencies = [
  "md-5",
  "nom 8.0.0",
  "nom_locate",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rangemap",
  "rayon",
  "sha2",
@@ -1701,7 +1701,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "metrics",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -1906,7 +1906,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.3",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2231,9 +2231,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",


### PR DESCRIPTION
## Summary

Closes (or partially addresses) two open Dependabot alerts against `memvid-service/Cargo.lock`.

### Alert #50 — `rustls-webpki` name-constraint bypass
- **Fix:** bump 0.103.10 → 0.103.12 (transitive, lockfile-only).
- **Severity:** low. Reachable only after cert signature verification and requires CA misissuance to exploit.

### Alert #47 — `rand` unsound with custom logger
- **Fix (partial):** bump rand 0.9.2 → 0.9.3 (one of two copies).
- **Residual:** rand 0.8.5 remains, pulled transitively through `memvid-core 2.0.139 → tantivy 0.25.0 → tantivy-stacker 0.6.0 → rand_distr 0.4.3` (which pins `rand ^0.8`). There is no 0.8.x patch — the fix ships only in 0.9.3 — and memvid-core 2.0.139 is the latest release, so removing the 0.8.5 entry is **blocked upstream**.
- **Exploit surface:** negligible for this service. The bug only triggers when a custom `log::Log` implementation calls `rand::thread_rng()` during reseeding. Our tracing/metrics stack does not.

If Dependabot does not auto-close alert #47 after this bump, suggest dismissing it as `inaccurate` (transitive, unreachable) with a link back to this PR and a note to revisit when memvid-core picks up tantivy ≥ 0.26.

## Test plan

- [x] `cargo update -p rustls-webpki --precise 0.103.12`
- [x] `cargo update -p rand@0.9.2 --precise 0.9.3`
- [x] `cargo check --all-targets` — clean after both bumps
- [ ] CI green on PR branch

Closes https://github.com/schwichtgit/ai-resume/security/dependabot/50
Partially addresses https://github.com/schwichtgit/ai-resume/security/dependabot/47