### PR TITLE
build(container): split build-all, add per-service task targets, verify-quality Tier-1 delegation

### DIFF
--- a/.claude/hooks/verify-quality.sh
+++ b/.claude/hooks/verify-quality.sh
@@ -1,134 +1,91 @@
 #!/bin/bash
-# Verify-quality hook: Run quality checks before stopping
-# This hook is called when Claude Code is about to stop working
+# Verify-quality hook: run quality checks before Claude Code stops.
+#
+# Reference implementation for upstream cpf CR:
+#   .specify/proposals/cr-ci-base-scaffold-issues.md#4
+#
+# Strategy: Tier-1 Taskfile delegation.
+#   The repo's own Taskfile knows how each service's venv, toolchain, and
+#   exclusions are wired. Calling `task lint` / `task test` avoids the
+#   PATH-based tool resolution that breaks in polyglot monorepos (e.g.
+#   picking up deployment/'s pytest when scanning ingest/).
+#
+# Severity contract (preserved from the previous per-service script):
+#   ERROR     -> `task lint` failure. Blocks Stop (exit 2).
+#   WARNING   -> `task test` failure. Non-blocking, surfaced at end.
+#   INFO      -> noisy sub-command output (warnings from underlying tools
+#                that don't flip their own exit code: ESLint warning lines,
+#                Rust build notes, prettier/markdown clean diffs, etc.).
+#
+# `task` itself is exit-code binary, so per-linter warning/error semantics
+# are owned by each linter:
+#   - ESLint: warnings print but exit 0 unless --max-warnings tripped.
+#   - Clippy: `-D warnings` promotes warnings to errors (memvid:lint).
+#   - Ruff / Mypy / Prettier / markdownlint / shellcheck: strict, exit 0
+#     means clean. This matches CI behavior.
 
 set -euo pipefail
 
-# Read JSON input from stdin and check for infinite loop prevention
+# Infinite-loop guard
 INPUT="$(cat)"
-STOP_HOOK_ACTIVE="$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('stop_hook_active', False))" 2>/dev/null || echo "False")"
+STOP_HOOK_ACTIVE="$(echo "$INPUT" | python3 -c \
+    "import sys,json; print(json.load(sys.stdin).get('stop_hook_active', False))" \
+    2>/dev/null || echo "False")"
 if [[ "$STOP_HOOK_ACTIVE" == "True" ]]; then
     exit 0
 fi
 
-# Get the project root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-echo "Running quality verification checks..."
+# Ensure rustup-managed cargo is reachable for memvid lint / test.
+if [[ -d "$HOME/.cargo/bin" ]]; then
+    export PATH="$HOME/.cargo/bin:$PATH"
+fi
+
+# Preconditions for Tier-1 delegation.
+if ! command -v task >/dev/null 2>&1; then
+    echo "verify-quality: 'task' not installed; skipping quality checks" >&2
+    exit 0
+fi
+if [[ ! -f "$PROJECT_ROOT/Taskfile.yml" ]]; then
+    echo "verify-quality: no Taskfile.yml at $PROJECT_ROOT; skipping quality checks" >&2
+    exit 0
+fi
+
+echo "Running quality verification via Taskfile delegation..."
 
 FAILED=0
 WARNINGS=0
 
-# Helper function to run a check
-run_check() {
-    local name="$1"
-    local command="$2"
-    local working_dir="${3:-$PROJECT_ROOT}"
-
-    echo -n "  Checking $name... "
-    if (cd "$working_dir" && eval "$command" > /dev/null 2>&1); then
-        echo "PASS"
-        return 0
-    else
-        echo "FAIL"
-        return 1
-    fi
-}
-
-# Helper function for optional checks (warnings only)
-run_optional_check() {
-    local name="$1"
-    local command="$2"
-    local working_dir="${3:-$PROJECT_ROOT}"
-
-    echo -n "  Checking $name... "
-    if (cd "$working_dir" && eval "$command" > /dev/null 2>&1); then
-        echo "PASS"
-        return 0
-    else
-        echo "WARN"
-        return 1
-    fi
-}
-
 echo ""
-echo "=== Frontend Checks (frontend/) ==="
-if [[ -d "$PROJECT_ROOT/frontend" ]] && [[ -f "$PROJECT_ROOT/frontend/package.json" ]]; then
-    # Check if node_modules exists
-    if [[ -d "$PROJECT_ROOT/frontend/node_modules" ]]; then
-        run_check "ESLint" "npm run lint" "$PROJECT_ROOT/frontend" || FAILED=$((FAILED + 1))
-        run_check "TypeScript" "npx tsc --noEmit" "$PROJECT_ROOT/frontend" || FAILED=$((FAILED + 1))
-        run_optional_check "Tests" "npm test -- --run" "$PROJECT_ROOT/frontend" || WARNINGS=$((WARNINGS + 1))
-    else
-        echo "  Skipping: node_modules not installed"
-    fi
-else
-    echo "  Skipping: frontend directory not found"
+echo "=== task lint (blocking) ==="
+if ! (cd "$PROJECT_ROOT" && task lint); then
+    FAILED=$((FAILED + 1))
 fi
 
 echo ""
-echo "=== API Service Checks (api-service/) ==="
-if [[ -d "$PROJECT_ROOT/api-service" ]] && command -v uv &> /dev/null; then
-    run_check "Ruff lint" "uv run ruff check ." "$PROJECT_ROOT/api-service" || FAILED=$((FAILED + 1))
-    run_check "Ruff format" "uv run ruff format --check ." "$PROJECT_ROOT/api-service" || FAILED=$((FAILED + 1))
-    run_check "Mypy" "uv run mypy ." "$PROJECT_ROOT/api-service" || FAILED=$((FAILED + 1))
-    run_optional_check "Pytest" "uv run pytest --tb=no -q" "$PROJECT_ROOT/api-service" || WARNINGS=$((WARNINGS + 1))
-else
-    echo "  Skipping: api-service directory not found or uv not installed"
-fi
-
-echo ""
-echo "=== Ingest Checks (ingest/) ==="
-if [[ -d "$PROJECT_ROOT/ingest" ]] && command -v uv &> /dev/null; then
-    run_check "Ruff lint" "uv run ruff check ." "$PROJECT_ROOT/ingest" || FAILED=$((FAILED + 1))
-    run_check "Ruff format" "uv run ruff format --check ." "$PROJECT_ROOT/ingest" || FAILED=$((FAILED + 1))
-else
-    echo "  Skipping: ingest directory not found or uv not installed"
-fi
-
-echo ""
-echo "=== Memvid Service Checks (memvid-service/) ==="
-if [[ -d "$PROJECT_ROOT/memvid-service" ]] && [[ -f "$PROJECT_ROOT/memvid-service/Cargo.toml" ]]; then
-    # Ensure cargo is on PATH (rustup default location)
-    if [[ -d "$HOME/.cargo/bin" ]]; then
-        export PATH="$HOME/.cargo/bin:$PATH"
-    fi
-    if command -v cargo &> /dev/null; then
-        run_check "Cargo check" "cargo check" "$PROJECT_ROOT/memvid-service" || FAILED=$((FAILED + 1))
-        run_optional_check "Cargo clippy" "cargo clippy -- -D warnings" "$PROJECT_ROOT/memvid-service" || WARNINGS=$((WARNINGS + 1))
-        run_optional_check "Cargo test" "cargo test --no-run" "$PROJECT_ROOT/memvid-service" || WARNINGS=$((WARNINGS + 1))
-    else
-        echo "  Skipping: cargo not found"
-    fi
-else
-    echo "  Skipping: memvid-service directory not found"
-fi
-
-echo ""
-echo "=== Markdown Lint Checks ==="
-if [[ -d "$PROJECT_ROOT/frontend/node_modules" ]]; then
-    run_check "Markdown lint" "npx --prefix '$PROJECT_ROOT/frontend' markdownlint-cli2 '**/*.md'" "$PROJECT_ROOT" || FAILED=$((FAILED + 1))
-else
-    echo "  Skipping: frontend/node_modules not found"
+echo "=== task test (advisory) ==="
+if ! (cd "$PROJECT_ROOT" && task test); then
+    WARNINGS=$((WARNINGS + 1))
 fi
 
 echo ""
 echo "=== Summary ==="
-echo "Failed checks: $FAILED"
-echo "Warnings: $WARNINGS"
+echo "Blocking failures: $FAILED"
+echo "Advisory warnings: $WARNINGS"
 
 if [[ $FAILED -gt 0 ]]; then
     echo "" >&2
-    echo "Quality checks failed. Please fix the issues before stopping." >&2
+    echo "Lint failures must be fixed before stopping." >&2
     exit 2
 fi
 
 if [[ $WARNINGS -gt 0 ]]; then
     echo ""
-    echo "Some optional checks had warnings. Consider reviewing them."
+    echo "Tests have failures (non-blocking). Review before committing."
 fi
 
 echo ""
-echo "All required quality checks passed!"
+echo "All required quality checks passed."
 exit 0

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -163,6 +163,26 @@ tasks:
     cmds:
       - task: deploy:build
 
+  container:build:frontend:
+    desc: Build only the frontend container image
+    cmds:
+      - task: deploy:build:frontend
+
+  container:build:api:
+    desc: Build only the API service container image
+    cmds:
+      - task: deploy:build:api
+
+  container:build:memvid:
+    desc: Build only the memvid service container image
+    cmds:
+      - task: deploy:build:memvid
+
+  container:build:ingest:
+    desc: Build only the ingest container image
+    cmds:
+      - task: deploy:build:ingest
+
   container:export:
     desc: Export containers as tar files
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -79,8 +79,17 @@ tasks:
       - test "$(git config core.hooksPath)" = ".githooks"
 
   lint:
-    desc: Lint all services
-    deps: [frontend:lint, api:lint, memvid:lint, ingest:lint, docs:lint]
+    desc: Lint all services and root assets (matches CI ci-base coverage)
+    deps:
+      [
+        frontend:lint,
+        api:lint,
+        memvid:lint,
+        ingest:lint,
+        lint:markdown,
+        lint:prettier,
+        lint:shellcheck,
+      ]
 
   lint:fix:
     desc: Lint all services with auto-fix
@@ -92,6 +101,27 @@ tasks:
         ingest:lint:fix,
         docs:lint:fix,
       ]
+
+  lint:shellcheck:
+    desc: Run shellcheck across repo shell scripts (matches CI ci-base/shellcheck)
+    cmds:
+      - |
+        find . -name '*.sh' \
+          -not -path './.git/*' \
+          -not -path '*/.venv/*' \
+          -not -path '*/node_modules/*' \
+          -not -path '*/target/*' \
+          -print0 | xargs -0 shellcheck -x
+
+  lint:prettier:
+    desc: Run prettier --check against the repo (matches CI ci-base/prettier)
+    cmds:
+      - npx --prefix frontend prettier --check .
+
+  lint:markdown:
+    desc: Run markdownlint-cli2 (matches CI ci-base/markdownlint)
+    cmds:
+      - npx --prefix frontend markdownlint-cli2 '**/*.md'
 
   test:
     desc: Unit test all services
@@ -131,7 +161,6 @@ tasks:
       - task: ingest:typecheck
       - task: test:coverage
       - task: build
-      - task: docs:lint
 
   proto:
     desc: Regenerate gRPC Python stubs
@@ -224,9 +253,9 @@ tasks:
       - task: memvid:dev
 
   docs:lint:
-    desc: Lint Markdown files
+    desc: Alias for lint:markdown (kept for backward compat)
     cmds:
-      - npx --prefix frontend markdownlint-cli2 '**/*.md'
+      - task: lint:markdown
 
   docs:lint:fix:
     desc: Lint and fix Markdown files

--- a/api-service/Dockerfile
+++ b/api-service/Dockerfile
@@ -2,14 +2,14 @@ ARG BUILD_VERSION=dev
 ARG BUILD_COMMIT=unknown
 
 # --- Stage 1: Builder ---
-# Full UBI 10 with dnf, compilers, and uv for building the production venv
-FROM registry.access.redhat.com/ubi10/ubi AS builder
+# Rocky 10 minimal (microdnf) with compilers and uv for building the production venv
+FROM rockylinux/rockylinux:10-minimal AS builder
 
 # Install Python 3.12 + build toolchain for native extensions (grpcio)
-RUN dnf install -y --nodocs \
+RUN microdnf install -y --nodocs \
     python3.12 python3.12-devel \
     gcc gcc-c++ \
-    && dnf clean all
+    && microdnf clean all
 
 # Grab the uv binary from the official image
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
@@ -32,9 +32,9 @@ ARG BUILD_COMMIT
 RUN printf '{"version":"%s","commit":"%s"}\n' "${BUILD_VERSION}" "${BUILD_COMMIT}" > /app/VERSION
 
 # --- Stage 2: Python runtime staging ---
-# ubi-minimal has microdnf to install Python + shared libraries, then we
+# Rocky 10 minimal has microdnf to install Python + shared libraries, then we
 # stage everything into /python-runtime/ for a single COPY into ubi-micro.
-FROM registry.access.redhat.com/ubi10/ubi-minimal AS python-deps
+FROM rockylinux/rockylinux:10-minimal AS python-deps
 
 RUN microdnf install -y --nodocs \
     python3.12 \

--- a/deployment/Taskfile.yml
+++ b/deployment/Taskfile.yml
@@ -13,6 +13,38 @@ tasks:
     cmds:
       - ../scripts/build-all.sh {{.VERSION}}
 
+  build:frontend:
+    desc: Build only the frontend container image
+    preconditions:
+      - sh: command -v podman
+        msg: 'podman not found.'
+    cmds:
+      - ../scripts/build-frontend.sh {{.VERSION}}
+
+  build:api:
+    desc: Build only the API service container image
+    preconditions:
+      - sh: command -v podman
+        msg: 'podman not found.'
+    cmds:
+      - ../scripts/build-api.sh {{.VERSION}}
+
+  build:memvid:
+    desc: Build only the memvid service container image
+    preconditions:
+      - sh: command -v podman
+        msg: 'podman not found.'
+    cmds:
+      - ../scripts/build-memvid.sh {{.VERSION}}
+
+  build:ingest:
+    desc: Build only the ingest container image
+    preconditions:
+      - sh: command -v podman
+        msg: 'podman not found.'
+    cmds:
+      - ../scripts/build-ingest.sh {{.VERSION}}
+
   export:
     desc: Export container images as tar files
     preconditions:

--- a/ingest/Dockerfile
+++ b/ingest/Dockerfile
@@ -2,14 +2,14 @@ ARG BUILD_VERSION=dev
 ARG BUILD_COMMIT=unknown
 
 # --- Stage 1: Builder ---
-# Full UBI 10 with dnf, compilers, and uv for building the production venv
-FROM registry.access.redhat.com/ubi10/ubi AS builder
+# Rocky 10 minimal (microdnf) with compilers and uv for building the production venv
+FROM rockylinux/rockylinux:10-minimal AS builder
 
 # Install Python 3.12 + build toolchain for native extensions
-RUN dnf install -y --nodocs \
+RUN microdnf install -y --nodocs \
         python3.12 python3.12-devel \
         gcc gcc-c++ \
-    && dnf clean all
+    && microdnf clean all
 
 # Grab the uv binary from the official image
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
@@ -39,9 +39,9 @@ ARG BUILD_COMMIT
 RUN printf '{"version":"%s","commit":"%s"}\n' "${BUILD_VERSION}" "${BUILD_COMMIT}" > /app/VERSION
 
 # --- Stage 2: Python runtime staging ---
-# ubi-minimal has microdnf to install Python + shared libraries, then we
+# Rocky 10 minimal has microdnf to install Python + shared libraries, then we
 # stage everything into /python-runtime/ for a single COPY into ubi-micro.
-FROM registry.access.redhat.com/ubi10/ubi-minimal AS python-deps
+FROM rockylinux/rockylinux:10-minimal AS python-deps
 
 RUN microdnf install -y --nodocs \
         python3.12 \

--- a/memvid-service/Dockerfile
+++ b/memvid-service/Dockerfile
@@ -36,7 +36,8 @@ ENV RUST_MIN_STACK=16777216
 
 # Create dummy sources to cache dependencies (both lib.rs and main.rs
 # are required because Cargo.toml declares [lib] + [[bin]] targets)
-RUN uname -m && rustup show && \
+RUN set -eux; \
+    uname -m && rustup show && \
     mkdir src && \
     echo "fn main() {}" > src/main.rs && \
     echo "" > src/lib.rs && \

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# Multi-architecture container build script for Hybrid Rust + Python setup
-# Builds frontend (nginx+React), Rust memvid service, and Python API service
+# Multi-architecture container build orchestrator.
+# Delegates to per-service scripts (build-<service>.sh) so any one
+# container can be rebuilt in isolation via task container:build:<service>.
 #
 # Usage:
 #   ./build-all.sh [version] [--no-cache] [--skip-frontend]
@@ -12,229 +13,92 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/container-build.sh
+source "${SCRIPT_DIR}/lib/container-build.sh"
+REPO_ROOT="$(container_build_repo_root)"
+cd "${REPO_ROOT}"
+
+require_podman
+
 VERSION="${1:-latest}"
 REGISTRY="${REGISTRY:-localhost}"
 NO_CACHE=""
 SKIP_FRONTEND=false
 
-# Parse additional arguments
 shift || true
 while [[ $# -gt 0 ]]; do
-    case $1 in
-        --no-cache)
-            NO_CACHE="--no-cache"
-            shift
-            ;;
-        --skip-frontend)
-            SKIP_FRONTEND=true
-            shift
-            ;;
-        *)
-            shift
-            ;;
+    case "$1" in
+        --no-cache) NO_CACHE="--no-cache" ;;
+        --skip-frontend) SKIP_FRONTEND=true ;;
+        *) ;;
     esac
+    shift
 done
 
-# Colors for output
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m'
-
-log_info() {
-    echo -e "${GREEN}[INFO]${NC} $1"
-}
-
-log_warn() {
-    echo -e "${YELLOW}[WARN]${NC} $1"
-}
-
-log_error() {
-    echo -e "${RED}[ERROR]${NC} $1"
-}
-
-# Check if podman is installed
-if ! command -v podman &> /dev/null; then
-    log_error "podman is not installed. Please install podman first."
-    exit 1
-fi
-
-# Change to project root directory
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "${SCRIPT_DIR}/.."
-
-# OCI image metadata (dynamic values injected at build time)
-BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-GIT_REVISION=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+export REGISTRY VERSION NO_CACHE
 
 log_info "Building multi-arch containers for Hybrid Rust + Python setup"
 log_info "Version: ${VERSION}"
 log_info "Registry: ${REGISTRY}"
-log_info "Revision: ${GIT_REVISION}"
-log_info "Build date: ${BUILD_DATE}"
 log_info "Platforms: linux/amd64, linux/arm64"
-[[ -n "$NO_CACHE" ]] && log_info "Cache: disabled"
+[[ -n "${NO_CACHE}" ]] && log_info "Cache: disabled"
 echo ""
 
-# Sync proto files from authoritative source before building
-# Uses hard links to keep proto files synchronized across build contexts
-log_info "Syncing proto files from authoritative source..."
-mkdir -p api-service/proto/memvid/v1 memvid-service/proto/memvid/v1
-ln -f proto/memvid/v1/memvid.proto api-service/proto/memvid/v1/memvid.proto 2>/dev/null || log_warn "Failed to link to api-service"
-ln -f proto/memvid/v1/memvid.proto memvid-service/proto/memvid/v1/memvid.proto 2>/dev/null || log_warn "Failed to link to memvid-service"
-log_info "Proto files synced"
-echo ""
-
-# Build frontend (React SPA + nginx)
-log_info "[1/4] Building frontend container..."
-if [ "$SKIP_FRONTEND" = true ]; then
+# Assemble the list of per-service builds to run.
+services=()
+if [[ "${SKIP_FRONTEND}" != "true" ]]; then
+    services+=("frontend")
+else
     log_warn "Skipping frontend build (--skip-frontend)"
-elif [ -f "frontend/Dockerfile" ]; then
-    # Remove existing manifest to avoid conflicts
-    podman manifest rm "${REGISTRY}/ai-resume-frontend:${VERSION}" 2>/dev/null || true
-    podman build \
-        ${NO_CACHE} \
-        --platform linux/amd64,linux/arm64 \
-        --manifest "${REGISTRY}/ai-resume-frontend:${VERSION}" \
-        --build-arg "BUILD_VERSION=${VERSION}" \
-        --build-arg "BUILD_COMMIT=${GIT_REVISION}" \
-        --annotation "org.opencontainers.image.title=ai-resume-frontend" \
-        --annotation "org.opencontainers.image.description=React SPA with OpenResty reverse proxy" \
-        --annotation "org.opencontainers.image.url=https://github.com/schwichtgit/ai-resume/pkgs/container/ai-resume-frontend" \
-        --annotation "org.opencontainers.image.source=https://github.com/schwichtgit/ai-resume" \
-        --annotation "org.opencontainers.image.documentation=https://github.com/schwichtgit/ai-resume#readme" \
-        --annotation "org.opencontainers.image.version=${VERSION}" \
-        --annotation "org.opencontainers.image.created=${BUILD_DATE}" \
-        --annotation "org.opencontainers.image.revision=${GIT_REVISION}" \
-        --annotation "org.opencontainers.image.licenses=PolyForm-Noncommercial-1.0.0 OR LicenseRef-Commercial" \
-        --annotation "org.opencontainers.image.vendor=schwichtgit" \
-        --annotation "org.opencontainers.image.authors=https://github.com/schwichtgit" \
-        -f frontend/Dockerfile \
-        frontend/
-    log_info "Frontend built successfully"
-else
-    log_warn "frontend/Dockerfile not found, skipping"
 fi
-echo ""
+services+=("memvid" "api" "ingest")
 
-# Build Rust memvid service
-log_info "[2/4] Building Rust memvid service..."
-if [ -f "memvid-service/Dockerfile" ]; then
-    # Remove existing manifest to avoid conflicts
-    podman manifest rm "${REGISTRY}/ai-resume-memvid:${VERSION}" 2>/dev/null || true
-    podman build \
-        ${NO_CACHE} \
-        --platform linux/amd64,linux/arm64 \
-        --manifest "${REGISTRY}/ai-resume-memvid:${VERSION}" \
-        --build-arg "BUILD_VERSION=${VERSION}" \
-        --build-arg "BUILD_COMMIT=${GIT_REVISION}" \
-        --annotation "org.opencontainers.image.title=ai-resume-memvid" \
-        --annotation "org.opencontainers.image.description=Rust gRPC service for semantic search over resume data" \
-        --annotation "org.opencontainers.image.url=https://github.com/schwichtgit/ai-resume/pkgs/container/ai-resume-memvid" \
-        --annotation "org.opencontainers.image.source=https://github.com/schwichtgit/ai-resume" \
-        --annotation "org.opencontainers.image.documentation=https://github.com/schwichtgit/ai-resume#readme" \
-        --annotation "org.opencontainers.image.version=${VERSION}" \
-        --annotation "org.opencontainers.image.created=${BUILD_DATE}" \
-        --annotation "org.opencontainers.image.revision=${GIT_REVISION}" \
-        --annotation "org.opencontainers.image.licenses=PolyForm-Noncommercial-1.0.0 OR LicenseRef-Commercial" \
-        --annotation "org.opencontainers.image.vendor=schwichtgit" \
-        --annotation "org.opencontainers.image.authors=https://github.com/schwichtgit" \
-        -f memvid-service/Dockerfile \
-        memvid-service/
-    log_info "Rust memvid service built successfully"
-else
-    log_warn "memvid-service/Dockerfile not found, skipping"
-fi
-echo ""
+total="${#services[@]}"
+idx=0
+for svc in "${services[@]}"; do
+    idx=$((idx + 1))
+    echo ""
+    log_info "[${idx}/${total}] Delegating to scripts/build-${svc}.sh"
+    # Pass through version + cache flag; per-service script honors REGISTRY from env.
+    if [[ -n "${NO_CACHE}" ]]; then
+        "${SCRIPT_DIR}/build-${svc}.sh" "${VERSION}" --no-cache
+    else
+        "${SCRIPT_DIR}/build-${svc}.sh" "${VERSION}"
+    fi
+done
 
-# Build Python API service
-log_info "[3/4] Building Python API service..."
-if [ -f "api-service/Dockerfile" ]; then
-    # Remove existing manifest to avoid conflicts
-    podman manifest rm "${REGISTRY}/ai-resume-api:${VERSION}" 2>/dev/null || true
-    podman build \
-        ${NO_CACHE} \
-        --platform linux/amd64,linux/arm64 \
-        --manifest "${REGISTRY}/ai-resume-api:${VERSION}" \
-        --build-arg "BUILD_VERSION=${VERSION}" \
-        --build-arg "BUILD_COMMIT=${GIT_REVISION}" \
-        --annotation "org.opencontainers.image.title=ai-resume-api" \
-        --annotation "org.opencontainers.image.description=FastAPI backend for profile API and gRPC client" \
-        --annotation "org.opencontainers.image.url=https://github.com/schwichtgit/ai-resume/pkgs/container/ai-resume-api" \
-        --annotation "org.opencontainers.image.source=https://github.com/schwichtgit/ai-resume" \
-        --annotation "org.opencontainers.image.documentation=https://github.com/schwichtgit/ai-resume#readme" \
-        --annotation "org.opencontainers.image.version=${VERSION}" \
-        --annotation "org.opencontainers.image.created=${BUILD_DATE}" \
-        --annotation "org.opencontainers.image.revision=${GIT_REVISION}" \
-        --annotation "org.opencontainers.image.licenses=PolyForm-Noncommercial-1.0.0 OR LicenseRef-Commercial" \
-        --annotation "org.opencontainers.image.vendor=schwichtgit" \
-        --annotation "org.opencontainers.image.authors=https://github.com/schwichtgit" \
-        -f api-service/Dockerfile \
-        api-service/
-    log_info "Python API service built successfully"
-else
-    log_warn "api-service/Dockerfile not found, skipping"
-fi
 echo ""
-
-# Build Python ingest service
-log_info "[4/4] Building Python ingest service..."
-if [ -f "ingest/Dockerfile" ]; then
-    # Remove existing manifest to avoid conflicts
-    podman manifest rm "${REGISTRY}/ai-resume-ingest:${VERSION}" 2>/dev/null || true
-    podman build \
-        ${NO_CACHE} \
-        --platform linux/amd64,linux/arm64 \
-        --manifest "${REGISTRY}/ai-resume-ingest:${VERSION}" \
-        --build-arg "BUILD_VERSION=${VERSION}" \
-        --build-arg "BUILD_COMMIT=${GIT_REVISION}" \
-        --annotation "org.opencontainers.image.title=ai-resume-ingest" \
-        --annotation "org.opencontainers.image.description=Data ingestion pipeline for .mv2 file creation" \
-        --annotation "org.opencontainers.image.url=https://github.com/schwichtgit/ai-resume/pkgs/container/ai-resume-ingest" \
-        --annotation "org.opencontainers.image.source=https://github.com/schwichtgit/ai-resume" \
-        --annotation "org.opencontainers.image.documentation=https://github.com/schwichtgit/ai-resume#readme" \
-        --annotation "org.opencontainers.image.version=${VERSION}" \
-        --annotation "org.opencontainers.image.created=${BUILD_DATE}" \
-        --annotation "org.opencontainers.image.revision=${GIT_REVISION}" \
-        --annotation "org.opencontainers.image.licenses=PolyForm-Noncommercial-1.0.0 OR LicenseRef-Commercial" \
-        --annotation "org.opencontainers.image.vendor=schwichtgit" \
-        --annotation "org.opencontainers.image.authors=https://github.com/schwichtgit" \
-        -f ingest/Dockerfile \
-        ingest/
-    log_info "Ingest service built successfully"
-else
-    log_warn "ingest/Dockerfile not found, skipping"
-fi
-echo ""
-
 log_info "All containers built successfully"
-echo ""
 
-# Show manifest info
+echo ""
 log_info "Manifest architectures:"
 for img in ai-resume-frontend ai-resume-memvid ai-resume-api ai-resume-ingest; do
     if podman manifest exists "${REGISTRY}/${img}:${VERSION}" 2>/dev/null; then
-        archs=$(podman manifest inspect "${REGISTRY}/${img}:${VERSION}" 2>/dev/null | grep -o '"architecture": "[^"]*"' | cut -d'"' -f4 | tr '\n' ' ')
+        archs="$(podman manifest inspect "${REGISTRY}/${img}:${VERSION}" 2>/dev/null \
+            | grep -o '"architecture": "[^"]*"' | cut -d'"' -f4 | tr '\n' ' ')"
         echo "  ${img}: ${archs:-unknown}"
     fi
 done
-echo ""
 
+echo ""
 echo "To inspect manifests:"
-echo "  podman manifest inspect ${REGISTRY}/ai-resume-frontend:${VERSION}"
-echo "  podman manifest inspect ${REGISTRY}/ai-resume-memvid:${VERSION}"
-echo "  podman manifest inspect ${REGISTRY}/ai-resume-api:${VERSION}"
-echo "  podman manifest inspect ${REGISTRY}/ai-resume-ingest:${VERSION}"
+for img in ai-resume-frontend ai-resume-memvid ai-resume-api ai-resume-ingest; do
+    echo "  podman manifest inspect ${REGISTRY}/${img}:${VERSION}"
+done
+
 echo ""
 echo "To save for transfer to edge server:"
-echo "  podman save --multi-image-archive ${REGISTRY}/ai-resume-frontend:${VERSION} -o frontend-${VERSION}.tar"
-echo "  podman save --multi-image-archive ${REGISTRY}/ai-resume-memvid:${VERSION} -o memvid-${VERSION}.tar"
-echo "  podman save --multi-image-archive ${REGISTRY}/ai-resume-api:${VERSION} -o api-${VERSION}.tar"
-echo "  podman save --multi-image-archive ${REGISTRY}/ai-resume-ingest:${VERSION} -o ingest-${VERSION}.tar"
+for img in ai-resume-frontend ai-resume-memvid ai-resume-api ai-resume-ingest; do
+    svc="${img#ai-resume-}"
+    echo "  podman save --multi-image-archive ${REGISTRY}/${img}:${VERSION} -o ${svc}-${VERSION}.tar"
+done
+
 echo ""
 echo "To run a quick smoke test:"
 echo "  ./scripts/test-containers.sh"
+
 echo ""
-echo "To run locally with podman-compose:"
+echo "To run locally with podman compose:"
 echo "  cd deployment/"
-echo "  podman-compose up -d"
+echo "  podman compose up -d"

--- a/scripts/build-api.sh
+++ b/scripts/build-api.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Build the Python FastAPI container.
+# Usage: ./build-api.sh [version] [--no-cache]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/container-build.sh
+source "${SCRIPT_DIR}/lib/container-build.sh"
+REPO_ROOT="$(container_build_repo_root)"
+cd "${REPO_ROOT}"
+
+require_podman
+parse_container_build_args "$@"
+sync_proto_into "api-service"
+
+SERVICE="api"
+TITLE="ai-resume-api"
+DESCRIPTION="FastAPI backend for profile API and gRPC client"
+DOCKERFILE="api-service/Dockerfile"
+CONTEXT="api-service/"
+export SERVICE TITLE DESCRIPTION DOCKERFILE CONTEXT
+
+build_one_container

--- a/scripts/build-frontend.sh
+++ b/scripts/build-frontend.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Build the frontend (React SPA + OpenResty) container.
+# Usage: ./build-frontend.sh [version] [--no-cache]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/container-build.sh
+source "${SCRIPT_DIR}/lib/container-build.sh"
+REPO_ROOT="$(container_build_repo_root)"
+cd "${REPO_ROOT}"
+
+require_podman
+parse_container_build_args "$@"
+
+SERVICE="frontend"
+TITLE="ai-resume-frontend"
+DESCRIPTION="React SPA with OpenResty reverse proxy"
+DOCKERFILE="frontend/Dockerfile"
+CONTEXT="frontend/"
+export SERVICE TITLE DESCRIPTION DOCKERFILE CONTEXT
+
+build_one_container

--- a/scripts/build-ingest.sh
+++ b/scripts/build-ingest.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Build the Python ingest container.
+# Usage: ./build-ingest.sh [version] [--no-cache]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/container-build.sh
+source "${SCRIPT_DIR}/lib/container-build.sh"
+REPO_ROOT="$(container_build_repo_root)"
+cd "${REPO_ROOT}"
+
+require_podman
+parse_container_build_args "$@"
+
+SERVICE="ingest"
+TITLE="ai-resume-ingest"
+DESCRIPTION="Data ingestion pipeline for .mv2 file creation"
+DOCKERFILE="ingest/Dockerfile"
+CONTEXT="ingest/"
+export SERVICE TITLE DESCRIPTION DOCKERFILE CONTEXT
+
+build_one_container

--- a/scripts/build-memvid.sh
+++ b/scripts/build-memvid.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Build the Rust memvid gRPC container.
+# Usage: ./build-memvid.sh [version] [--no-cache]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/container-build.sh
+source "${SCRIPT_DIR}/lib/container-build.sh"
+REPO_ROOT="$(container_build_repo_root)"
+cd "${REPO_ROOT}"
+
+require_podman
+parse_container_build_args "$@"
+sync_proto_into "memvid-service"
+
+SERVICE="memvid"
+TITLE="ai-resume-memvid"
+DESCRIPTION="Rust gRPC service for semantic search over resume data"
+DOCKERFILE="memvid-service/Dockerfile"
+CONTEXT="memvid-service/"
+export SERVICE TITLE DESCRIPTION DOCKERFILE CONTEXT
+
+build_one_container

--- a/scripts/lib/container-build.sh
+++ b/scripts/lib/container-build.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Shared helpers for per-service container build scripts.
+# Source from scripts/build-<service>.sh.
+
+# Colors (guarded against re-definition when sourced multiple times)
+: "${GREEN:=$'\033[0;32m'}"
+: "${YELLOW:=$'\033[1;33m'}"
+: "${RED:=$'\033[0;31m'}"
+: "${NC:=$'\033[0m'}"
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Ensure podman is available
+require_podman() {
+    if ! command -v podman &>/dev/null; then
+        log_error "podman is not installed. Please install podman first."
+        exit 1
+    fi
+}
+
+# Resolve the repository root relative to this library.
+# Usage: REPO_ROOT="$(container_build_repo_root)"
+container_build_repo_root() {
+    local lib_dir
+    lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    cd "${lib_dir}/../.." && pwd
+}
+
+# Hard-link the authoritative proto into a service-local copy so the
+# build context can see it. Safe to call for services that need proto.
+sync_proto_into() {
+    local target_service_dir="$1"
+    local src="${REPO_ROOT}/proto/memvid/v1/memvid.proto"
+    local dst_dir="${REPO_ROOT}/${target_service_dir}/proto/memvid/v1"
+    mkdir -p "${dst_dir}"
+    ln -f "${src}" "${dst_dir}/memvid.proto" 2>/dev/null \
+        || log_warn "Failed to link proto into ${target_service_dir}"
+}
+
+# Build a single multi-arch container.
+# Required env vars (set by caller before invoking):
+#   SERVICE        - image suffix (e.g. frontend, api, memvid, ingest)
+#   TITLE          - OCI title
+#   DESCRIPTION    - OCI description
+#   DOCKERFILE     - path to Dockerfile (repo-relative)
+#   CONTEXT        - build context dir (repo-relative)
+# Optional:
+#   PLATFORMS      - default "linux/amd64,linux/arm64"
+#   REGISTRY       - default "localhost"
+#   VERSION        - default "latest"
+#   NO_CACHE       - pass "--no-cache" to enable; default unset
+build_one_container() {
+    : "${SERVICE:?SERVICE not set}"
+    : "${TITLE:?TITLE not set}"
+    : "${DESCRIPTION:?DESCRIPTION not set}"
+    : "${DOCKERFILE:?DOCKERFILE not set}"
+    : "${CONTEXT:?CONTEXT not set}"
+
+    local platforms="${PLATFORMS:-linux/amd64,linux/arm64}"
+    local registry="${REGISTRY:-localhost}"
+    local version="${VERSION:-latest}"
+    local no_cache="${NO_CACHE:-}"
+    local build_date
+    local git_revision
+    build_date="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    git_revision="$(git -C "${REPO_ROOT}" rev-parse HEAD 2>/dev/null || echo "unknown")"
+
+    local manifest="${registry}/ai-resume-${SERVICE}:${version}"
+
+    log_info "Building ${manifest}"
+    log_info "  platforms: ${platforms}"
+    log_info "  dockerfile: ${DOCKERFILE}"
+    log_info "  context: ${CONTEXT}"
+    [[ -n "${no_cache}" ]] && log_info "  cache: disabled"
+
+    # Remove any stale manifest with the same tag
+    podman manifest rm "${manifest}" 2>/dev/null || true
+
+    # shellcheck disable=SC2086  # Intentional word-split on ${no_cache}
+    podman build \
+        ${no_cache} \
+        --platform "${platforms}" \
+        --manifest "${manifest}" \
+        --build-arg "BUILD_VERSION=${version}" \
+        --build-arg "BUILD_COMMIT=${git_revision}" \
+        --annotation "org.opencontainers.image.title=ai-resume-${SERVICE}" \
+        --annotation "org.opencontainers.image.description=${DESCRIPTION}" \
+        --annotation "org.opencontainers.image.url=https://github.com/schwichtgit/ai-resume/pkgs/container/ai-resume-${SERVICE}" \
+        --annotation "org.opencontainers.image.source=https://github.com/schwichtgit/ai-resume" \
+        --annotation "org.opencontainers.image.documentation=https://github.com/schwichtgit/ai-resume#readme" \
+        --annotation "org.opencontainers.image.version=${version}" \
+        --annotation "org.opencontainers.image.created=${build_date}" \
+        --annotation "org.opencontainers.image.revision=${git_revision}" \
+        --annotation "org.opencontainers.image.licenses=PolyForm-Noncommercial-1.0.0 OR LicenseRef-Commercial" \
+        --annotation "org.opencontainers.image.vendor=schwichtgit" \
+        --annotation "org.opencontainers.image.authors=https://github.com/schwichtgit" \
+        -f "${DOCKERFILE}" \
+        "${CONTEXT}"
+
+    log_info "Built ${manifest}"
+}
+
+# Parse "[version] [--no-cache]" from per-service script args.
+# Sets globals VERSION and NO_CACHE.
+parse_container_build_args() {
+    VERSION="${1:-${VERSION:-latest}}"
+    NO_CACHE="${NO_CACHE:-}"
+    shift || true
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --no-cache) NO_CACHE="--no-cache" ;;
+            *) ;;
+        esac
+        shift
+    done
+    export VERSION NO_CACHE
+}


### PR DESCRIPTION
## Summary

- Split `scripts/build-all.sh` into per-service wrapper scripts (`build-frontend|api|memvid|ingest.sh`) sharing a new `scripts/lib/container-build.sh` helper. `build-all.sh` is now a thin orchestrator that delegates.
- Expose the per-service builds via Taskfile: `task container:build:{frontend,api,memvid,ingest}` (plus the existing `container:build` aggregate).
- Switch api-service + ingest Dockerfile builder/python-deps stages from `ubi10/ubi` to `rockylinux/rockylinux:10-minimal` (microdnf) to sidestep the UBI 10 OpenSSL 3.5.1 TLS bug under Rosetta 2; runtime stage still ubi10/ubi-micro.
- Reference implementation for cpf CR issue 4 (polyglot per-service venv resolution): the Stop hook now delegates to `task lint` (blocking) / `task test` (advisory) instead of probing PATH. Severity contract preserved (exit 2 on lint fail, non-blocking on test fail).
- Add per-tool lint targets to root Taskfile that mirror `ci-base.yml` one-for-one: `lint:shellcheck`, `lint:prettier`, `lint:markdown`. Aggregate `task lint` now includes them (closes prior CI/local parity gap).

## Commits

- `280bf33` build(container): switch api/ingest stages to rockylinux 10-minimal
- `441d804` build(container): split build-all into per-service scripts and task targets
- `76ec9a5` refactor(hooks): delegate verify-quality via task (CR issue 4 ref impl)

## Test plan

- [x] `task container:build:frontend` produces multi-arch manifest (local)
- [x] `task container:build:api` produces multi-arch manifest (local)
- [x] `task container:build:memvid` produces multi-arch manifest (local)
- [x] `task container:build:ingest` produces multi-arch manifest (local)
- [x] `scripts/build-all.sh` still builds all four services end-to-end
- [x] `podman-compose up` with locally-built images brings the stack up
- [x] Playwright E2E suite passes against local compose stack (10/10 including real-LLM chat)
- [x] `task lint` runs frontend + api + memvid + ingest + shellcheck + prettier + markdown
- [x] Stop hook `verify-quality.sh` via `task lint` + `task test` reports blocking vs advisory correctly
- [ ] CI green on all required gates