### PR TITLE
fix(deps): bump postcss to 8.5.10 (GHSA-qx2v-qp2m-jg93, alert #58)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6154,9 +6154,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Resolves Dependabot alert [#58](https://github.com/schwichtgit/ai-resume/security/dependabot/58) — `postcss` XSS via unescaped `</style>` in CSS stringify output (GHSA-qx2v-qp2m-jg93, medium severity).

- Transitive dev dependency of `vite@8.0.8` (only `frontend/package-lock.json` touched).
- Bumped `postcss` 8.5.8 → 8.5.10 via `npm update postcss`.
- `npm audit` now reports 0 vulnerabilities.

## Vulnerability detail

| Field | Value |
|-------|-------|
| Advisory | [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) |
| Severity | Medium |
| Vulnerable range | `< 8.5.10` |
| First patched version | `8.5.10` |
| Scope | `development` (dev dep, transitive) |

## Test plan

- [x] `npm ls postcss` shows `postcss@8.5.10` resolved under `vite`
- [x] `npm audit` returns 0 vulnerabilities
- [ ] CI green (frontend lint, typecheck, tests, build)
- [ ] Dependabot auto-closes alert #58 after merge