### PR TITLE
build(deps): bump container base images

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,7 @@ ARG BUILD_COMMIT=unknown
 # =============================================================================
 # Stage 1: Build React application
 # =============================================================================
-FROM node:24.13.1-bookworm-slim AS builder
+FROM node:24.15.0-bookworm-slim AS builder
 
 WORKDIR /app
 
@@ -37,7 +37,7 @@ RUN printf '{"version":"%s","commit":"%s"}\n' "${BUILD_VERSION}" "${BUILD_COMMIT
 # =============================================================================
 # Stage 2: Production OpenResty server (Alpine package)
 # =============================================================================
-FROM alpine:3.23.3
+FROM alpine:3.23.4
 
 # Install OpenResty and lua-resty-http, then create directories
 # Note: openresty package creates 'nginx' user and group automatically

--- a/memvid-service/Dockerfile
+++ b/memvid-service/Dockerfile
@@ -5,7 +5,7 @@ ARG BUILD_COMMIT=unknown
 # Supports amd64 and arm64 architectures
 
 # Stage 1: Build the Rust binary
-FROM rust:1.93.1-slim AS builder
+FROM rust:1.95.0-slim AS builder
 
 ARG TARGETARCH
 ARG PROTOC_VERSION=28.3


### PR DESCRIPTION
## Summary

Currency bump for three pinned container base images. Floating tags (`rockylinux:10-minimal`, `ubi10/ubi-micro`, `gcr.io/distroless/cc-debian12:nonroot`) are unchanged — already track upstream.

| File                          | From                          | To                            |
| ----------------------------- | ----------------------------- | ----------------------------- |
| `frontend/Dockerfile` (build) | `node:24.13.1-bookworm-slim`  | `node:24.15.0-bookworm-slim`  |
| `frontend/Dockerfile` (run)   | `alpine:3.23.3`               | `alpine:3.23.4`               |
| `memvid-service/Dockerfile`   | `rust:1.93.1-slim`            | `rust:1.95.0-slim`            |

## Notes

- **Why not distroless `cc-debian13`?** Only `:debug-nonroot-<sha>` digest tags are published on `gcr.io/distroless/cc-debian13`. The canonical `:nonroot` rolling tag is not yet available, so we stay on `cc-debian12:nonroot`.
- **Why not Node 25 / 26?** Node 24 is current Active LTS; sticking to LTS in CI/runtime.
- **Rust 1.95 MSRV check:** `axum 0.8.9` (current pin) requires Rust 1.80+. Tokio 1.52, Tonic 0.14 likewise satisfied.

## Test plan

- [ ] CI multi-arch container build green (frontend amd64 + arm64, memvid amd64 + arm64)
- [ ] Trivy scan: no new CRITICAL/HIGH findings introduced
- [ ] Image runs: frontend serves `/health`, memvid binds 50051