### PR TITLE
docs: release 0.1.0-alpha.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.16] - 2026-04-26
+
+### Changed
+
+- Dependency currency rollup consolidating 8 Dependabot PRs (#214)
+  - **api-service**: pydantic >=2.13.2 → >=2.13.3 (#207), opentelemetry-sdk >=1.29.0 → >=1.41.1 (#210), opentelemetry-exporter-otlp >=1.39.1 → >=1.41.1 (#209)
+  - **api-service (dev)**: pytest-cov >=6.0.0 → >=7.1.0 (#208), mypy >=1.20.1 → >=1.20.2 (#211)
+  - **frontend (minor-and-patch group, 10 updates)**: vite 8.0.8 → 8.0.10, vitest 4.1.4 → 4.1.5, @vitest/coverage-v8 4.1.4 → 4.1.5, @tanstack/react-query 5.99.2 → 5.100.5, lucide-react 1.8.0 → 1.11.0, react-hook-form 7.72.1 → 7.74.0, react-router-dom 7.14.1 → 7.14.2, tailwindcss 4.2.2 → 4.2.4, @tailwindcss/vite 4.2.2 → 4.2.4, typescript-eslint 8.58.2 → 8.59.0 (#213)
+  - **memvid-service**: axum 0.8.8 → 0.8.9, tokio 1.51.1 → 1.52.1 (#212)
+  - **github_actions**: aquasecurity/trivy-action 0.35.0 → v0.36.0 (#206)
+- Container base images bumped (#215)
+  - frontend builder: `node:24.13.1-bookworm-slim` → `node:24.15.0-bookworm-slim` (Node 24 Active LTS)
+  - frontend runtime: `alpine:3.23.3` → `alpine:3.23.4`
+  - memvid builder: `rust:1.93.1-slim` → `rust:1.95.0-slim` (satisfies axum 0.8.9 MSRV 1.80)
+  - Floating tags (`rockylinux:10-minimal`, `ubi10/ubi-micro`, `gcr.io/distroless/cc-debian12:nonroot`) unchanged; `cc-debian13:nonroot` not yet published as a stable rolling tag
+- poetry bumped from 2.3.3 to 2.3.4 in api-service (#201)
+- python-dotenv >=1.2.1 → >=1.2.2 in api-service and deployment (#199, #200)
+- rand bumped from 0.8.5 to 0.8.6 in memvid-service (#202) -- residual transitive dep via `tantivy 0.25 → tantivy-stacker 0.6 → rand_distr 0.4`; full remediation of GHSA-cq8v-f236-94qc (alert #542) is upstream-blocked pending `memvid-core` bumping to `tantivy 0.26`
+- rustls-webpki bumped from 0.103.12 to 0.103.13 in memvid-service (#203)
+
+### Security
+
+- postcss bumped from 8.5.8 to 8.5.10 in frontend (#204) -- closes Dependabot alert #58 (GHSA-qx2v-qp2m-jg93, XSS via unescaped `</style>` in CSS stringify output, dev dependency, transitive of vite)
+
+### Documentation
+
+- `docs/DEPLOYMENT.md`, `CLAUDE.md`: corrected stale runtime base-image claims (api-service / ingest are `ubi10/ubi-micro` with `rockylinux:10-minimal` builders, memvid-service is `gcr.io/distroless/cc-debian12:nonroot`)
+
 ## [0.1.0-alpha.15] - 2026-04-20
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,9 +348,9 @@ The application expects to be served at `frank-resume.schwichtenberg.us` when de
 
 - **Frontend base**: alpine:3.23 with OpenResty (runs as nginx user)
 - **Frontend build stage**: node:24-bookworm-slim for npm build
-- **API base**: ubi10/ubi-micro (3-stage build)
-- **Ingest base**: ubi10/ubi-micro (3-stage build)
-- **Memvid base**: debian:trixie-slim (runs as memvid user)
+- **API base**: ubi10/ubi-micro runtime, rockylinux:10-minimal builder (3-stage build)
+- **Ingest base**: ubi10/ubi-micro runtime, rockylinux:10-minimal builder (3-stage build)
+- **Memvid base**: gcr.io/distroless/cc-debian12:nonroot (runs as nonroot user)
 - **Frontend port**: 8080 (unprivileged)
 - **API port**: 3000
 - **Memvid port**: 50051 (gRPC)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -4,12 +4,12 @@
 
 The AI Resume stack consists of three runtime services plus a one-shot ingest pipeline:
 
-| Service            | Base Image                       | Port  | Protocol | Lifecycle  |
-| ------------------ | -------------------------------- | ----- | -------- | ---------- |
-| ai-resume-frontend | Alpine 3.23 (OpenResty/nginx)    | 8080  | HTTP     | Long-lived |
-| ai-resume-api      | Python 3.12 slim-bookworm        | 3000  | HTTP     | Long-lived |
-| ai-resume-memvid   | Debian trixie-slim (Rust binary) | 50051 | gRPC     | Long-lived |
-| ai-resume-ingest   | Python 3.12                      | --    | --       | One-shot   |
+| Service            | Runtime Base                             | Port  | Protocol | Lifecycle  |
+| ------------------ | ---------------------------------------- | ----- | -------- | ---------- |
+| ai-resume-frontend | alpine:3.23 (OpenResty/nginx)            | 8080  | HTTP     | Long-lived |
+| ai-resume-api      | ubi10/ubi-micro (Rocky Linux 10 builder) | 3000  | HTTP     | Long-lived |
+| ai-resume-memvid   | gcr.io/distroless/cc-debian12:nonroot    | 50051 | gRPC     | Long-lived |
+| ai-resume-ingest   | ubi10/ubi-micro (Rocky Linux 10 builder) | --    | --       | One-shot   |
 
 Traffic flow: reverse proxy -> frontend (8080) -> api (3000) -> memvid (50051 gRPC)
 


### PR DESCRIPTION
## Summary

Release notes for `0.1.0-alpha.16`. Doc-only — covers all version-changing PRs landed since alpha.15.

### Included
- **#214** — Dependabot currency rollup (8 PRs: api-service deps, frontend minor-and-patch group, memvid axum/tokio, trivy-action)
- **#215** — Container base image bumps (node 24.13.1→24.15.0, alpine 3.23.3→3.23.4, rust 1.93.1→1.95.0)
- **#204** — postcss 8.5.8→8.5.10 (Security: GHSA-qx2v-qp2m-jg93, Dependabot alert #58)
- **#199-203** — Individual dep bumps (python-dotenv, poetry, rand, rustls-webpki)

### Doc corrections
Stale runtime base-image claims in `docs/DEPLOYMENT.md` and the project guide updated to match the alpha.15 migration:
- api-service / ingest runtime: `ubi10/ubi-micro` (was wrongly listed as `Python 3.12 slim-bookworm`)
- memvid-service runtime: `gcr.io/distroless/cc-debian12:nonroot` (was wrongly listed as `Debian trixie-slim`)
- Rocky Linux 10 builder stages noted

## Deferred follow-ups
- Resume-agnostic e2e fixture (`fix/e2e-fixture-ingest-example-resume`): make `test_memvid_retrieval` ingest `data/example_resume.md` into a session-scoped temp `.mv2` so it stops false-failing locally when `data/.memvid/resume.mv2` was built from a different resume
- cpf upstream CR §4 (plugin verify-quality.sh): augment with this session's failure traces (deployment exit-5 false-positive, ingest pytest-from-wrong-venv)
- Optional: document the ingest container as a `task ingest:example` developer-bootstrap target

## Test plan

- [x] CHANGELOG entry follows Keep-a-Changelog format and includes all merged PRs since alpha.15
- [x] No code changes — doc-only diff
- [ ] CI green on this branch (markdownlint, prettier)
- [ ] Tag `v0.1.0-alpha.16` after merge