### PR TITLE
chore(deps): bump frontend node and memvid rust builders to Trixie

### DIFF
--- a/.specify/specs/plan.md
+++ b/.specify/specs/plan.md
@@ -1284,8 +1284,13 @@ Keep distroless-based runtime container images current with their upstream Debia
 ### Implementation Order
 
 ```text
-Phase 9 (single feature, no dependencies):
-  INFRA-091: Memvid distroless cc-debian12 -> cc-debian13 currency bump
+Phase 9a (shipped):
+  INFRA-091: Memvid distroless cc-debian12 -> cc-debian13 runtime bump
+
+Phase 9b (sequential, depends on 9a):
+  INFRA-092: Frontend node + memvid Rust BUILDER images Bookworm -> Trixie
+             + .trivyignore disposition of CVE-2026-5435 (alert #547,
+               residual unfixed glibc note from Phase 9a's runtime bump)
 ```
 
 ### Feature Summary
@@ -1293,21 +1298,27 @@ Phase 9 (single feature, no dependencies):
 | ID        | Title                                                  | Category       | Dependencies |
 | --------- | ------------------------------------------------------ | -------------- | ------------ |
 | INFRA-091 | Memvid Distroless Base Currency (debian12 -> debian13) | infrastructure | None         |
+| INFRA-092 | Builder Image Currency (Bookworm -> Trixie)            | infrastructure | INFRA-091    |
 
 ### Risk Assessment
 
-| Risk                                                      | Likelihood | Impact | Mitigation                                                                                          |
-| --------------------------------------------------------- | ---------- | ------ | --------------------------------------------------------------------------------------------------- |
-| Rust binary ABI breakage under Trixie glibc 2.41          | Low        | High   | `scripts/test-containers.sh` smoke test exercises gRPC roundtrip + healthcheck end-to-end           |
-| Multi-arch (amd64 + arm64) build regression               | Low        | Medium | `task container:build:memvid` produces both arches; build fails fast if either is broken            |
-| Trixie glibc missing one of the five upstream CVE patches | Low        | Low    | Re-clarify accepted: residual CVEs get a `revisit-YYYY-MM-DD` `.trivyignore` entry, not a hard fail |
-| Stale libssl3 suppression after layer removal             | Low        | Low    | `.trivyignore` line for `CVE-2026-28390` deleted as part of the same change                         |
+| Risk                                                       | Likelihood | Impact | Mitigation                                                                                          |
+| ---------------------------------------------------------- | ---------- | ------ | --------------------------------------------------------------------------------------------------- |
+| Rust binary ABI breakage under Trixie glibc 2.41           | Low        | High   | `scripts/test-containers.sh` smoke test exercises gRPC roundtrip + healthcheck end-to-end           |
+| Multi-arch (amd64 + arm64) build regression                | Low        | Medium | `task container:build:{memvid,frontend}` produces both arches; build fails fast if either is broken |
+| Trixie glibc missing one of the five upstream CVE patches  | Low        | Low    | Re-clarify accepted: residual CVEs get a `revisit-YYYY-MM-DD` `.trivyignore` entry, not a hard fail |
+| Stale libssl3 suppression after layer removal              | Low        | Low    | `.trivyignore` line for `CVE-2026-28390` deleted as part of the INFRA-091 change                    |
+| Node 24 + Trixie image surface drift (frontend builder)    | Low        | Medium | Frontend smoke (Test 8-11 in `test-containers.sh`) exercises served HTML and SPA routing            |
+| Net-new HIGH CVEs introduced by Trixie builder package set | Low        | Medium | INFRA-092 acceptance requires explicit before/after Trivy delta in PR body with disposition         |
 
 ### Verification Strategy
 
-INFRA-091 verification mirrors the standard container-bump pattern (see ADR-014 for the pipeline):
+Both features in this phase share the standard container-bump verification pipeline (see ADR-014 for the underlying CI pattern):
 
-1. `task container:build:memvid` succeeds for `linux/amd64` + `linux/arm64`.
-2. `bash scripts/test-containers.sh` passes (memvid `--health` + api↔memvid gRPC).
-3. Local Trivy scan with `--severity CRITICAL,HIGH --ignore-unfixed --trivyignores .trivyignore` returns zero unfixed glibc rows.
-4. After merge to `main`, manual `gh workflow run security.yml` confirms the Trivy SARIF on `main` no longer surfaces the five CVE IDs and code-scanning alerts #539/540/541/543/544 transition to `fixed`.
+1. `task container:build:{frontend,memvid}` succeeds for `linux/amd64` + `linux/arm64` on the affected service(s).
+2. `bash scripts/test-containers.sh` passes (default mocked mode -- binary-load smoke for both services).
+3. `MOCK_MEMVID_CLIENT=false bash scripts/test-containers.sh` passes (real api↔memvid gRPC ABI verification under the new toolchain).
+4. Local Trivy scan with `--severity CRITICAL,HIGH --ignore-unfixed --trivyignores .trivyignore` returns zero unfixed rows (or any net-new finding is dispositioned in the PR body and `.trivyignore`).
+5. After merge to `main`, manual `gh workflow run security.yml` confirms the Trivy SARIF on `main` no longer surfaces the corresponding CVE IDs.
+
+INFRA-091 specifically required that code-scanning alerts #539/540/541/543/544 transition to `fixed`. INFRA-092 specifically requires that alert #547 (CVE-2026-5435) is suppressed via `.trivyignore` with a `revisit-2026-08-01` comment, since it is unfixed upstream in Trixie at the time of this work.

--- a/.specify/specs/spec.md
+++ b/.specify/specs/spec.md
@@ -4644,3 +4644,29 @@ The following decisions were made during the spec and clarify phases:
 - [ ] After merge to `main`, the next Security Scan workflow run on `main` (manual `workflow_dispatch` is acceptable) uploads a Trivy SARIF for `ai-resume-memvid` that no longer surfaces CVE-2026-4046, CVE-2026-4437, CVE-2026-4438, CVE-2026-5450, or CVE-2026-5928, and GitHub code-scanning alerts #539, #540, #541, #543, and #544 transition to `fixed`
 
 **Dependencies:** None
+
+---
+
+### INFRA-092: Builder Image Currency (Bookworm → Trixie)
+
+**Description:** Bump the two Debian-based BUILDER images from Bookworm (Debian 12) to Trixie (Debian 13), aligning the entire build/runtime toolchain with the cc-debian13 runtime that landed in INFRA-091. Two changes:
+
+1. `frontend/Dockerfile` line 10: `node:24.15.0-bookworm-slim` → `node:24.15.0-trixie-slim`.
+2. `memvid-service/Dockerfile` line 8: `rust:1.95.0-slim` (currently the unsuffixed Bookworm default) → `rust:1.95.0-slim-trixie`.
+
+This is currency maintenance, not security remediation — no open CVEs drove this work. The motivation is preventing silent base-image drift (the `rust:*-slim` tag will silently flip from Bookworm to Trixie on a future DockerHub default change, identical to the gcr.io/distroless unsuffixed-tag risk addressed in ADR-032) and keeping builder/runtime glibc versions aligned (Trixie 2.41 builders producing for the Trixie 2.41 runtime, removing the cross-version forward-compat dance). Out of scope: api-service / ingest (Rocky/UBI bases, not Debian); frontend runtime (Alpine).
+
+**Acceptance Criteria:**
+
+- [ ] `frontend/Dockerfile` line 10 references `node:24.15.0-trixie-slim`
+- [ ] `memvid-service/Dockerfile` line 8 references `rust:1.95.0-slim-trixie` (explicit Trixie suffix, no longer relying on the unsuffixed default)
+- [ ] All Debian-based Dockerfile `FROM` lines in the repo explicitly pin a `-trixieN` suffix or equivalent (no unsuffixed tags that could silently drift across major Debian releases) — enforces ADR-032 across builders and runtimes alike
+- [ ] `task container:build:frontend` succeeds and produces a multi-arch (`linux/amd64` + `linux/arm64`) podman manifest
+- [ ] `task container:build:memvid` succeeds and produces a multi-arch (`linux/amd64` + `linux/arm64`) podman manifest
+- [ ] `bash scripts/test-containers.sh` (default mocked mode) passes all 11 checks
+- [ ] `MOCK_MEMVID_CLIENT=false bash scripts/test-containers.sh` (real api↔memvid gRPC roundtrip) passes all 11 checks
+- [ ] PR body includes a before/after Trivy summary for both `localhost/ai-resume-frontend` and `localhost/ai-resume-memvid` (`--severity CRITICAL,HIGH --ignore-unfixed`); any net-new CVEs introduced by the Trixie bump are explicitly listed and dispositioned (fix in this PR, or `wont-fix`/`revisit-YYYY-MM-DD` suppression in `.trivyignore` with rationale referencing the GitHub alert number once available)
+- [ ] `.trivyignore` is updated to suppress `CVE-2026-5435` (glibc 2.41 `ns_printrr`/`ns_printrrf`/`fp_nquery` deprecation, GitHub alert #547, severity `note`, unfixed upstream) with a `revisit-2026-08-01` comment referencing the alert number — residual from INFRA-091's cc-debian13 bump, surfaced by the post-merge Security Scan
+- [ ] After merge to `main`, the Security Scan workflow run on `main` succeeds for both `frontend` and `memvid` images, and the new `.trivyignore` entry causes Trivy to skip alert #547 in subsequent SARIF uploads
+
+**Dependencies:** INFRA-091 (the cc-debian13 runtime must already be in place so the memvid build/runtime glibc stays aligned, not skewed in the wrong direction; alert #547 also surfaces from the same runtime base and is dispositioned in this same PR)

--- a/.trivyignore
+++ b/.trivyignore
@@ -6,3 +6,5 @@
 #   CVE-2024-XXXXX  # accepted: no fix available, low exploitability in this context
 #
 # Reference: https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/#by-finding-ids
+
+CVE-2026-5435  # libc6 deprecated ns_printrr/ns_printrrf/fp_nquery family in glibc 2.41 (Trixie). Unfixed upstream. GitHub alert #547, severity note. Revisit 2026-08-01.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,7 +347,7 @@ The application expects to be served at `frank-resume.schwichtenberg.us` when de
 ### Container Architecture
 
 - **Frontend base**: alpine:3.23 with OpenResty (runs as nginx user)
-- **Frontend build stage**: node:24-bookworm-slim for npm build
+- **Frontend build stage**: node:24-trixie-slim for npm build
 - **API base**: ubi10/ubi-micro runtime, rockylinux:10-minimal builder (3-stage build)
 - **Ingest base**: ubi10/ubi-micro runtime, rockylinux:10-minimal builder (3-stage build)
 - **Memvid base**: gcr.io/distroless/cc-debian13:nonroot (runs as nonroot user)

--- a/feature_list.json
+++ b/feature_list.json
@@ -3352,6 +3352,28 @@
       ],
       "passes": false,
       "dependencies": []
+    },
+    {
+      "id": "builder-images-trixie",
+      "category": "infrastructure",
+      "title": "Builder Image Currency (Bookworm to Trixie)",
+      "description": "Bump the two Debian-based BUILDER images from Bookworm (Debian 12) to Trixie (Debian 13): frontend node:24.15.0-bookworm-slim -> -trixie-slim and memvid-service rust:1.95.0-slim (unsuffixed Bookworm default) -> rust:1.95.0-slim-trixie. Aligns the toolchain with the cc-debian13 runtime landed by INFRA-091, eliminates the unsuffixed-tag drift risk per ADR-032, and keeps builder/runtime glibc versions matched. Also dispositions GitHub code-scanning alert #547 (CVE-2026-5435, glibc deprecated ns_printrr family, severity note, unfixed upstream in Trixie) by adding it to .trivyignore with a revisit-2026-08-01 comment.",
+      "testing_steps": [
+        "Verify frontend/Dockerfile line 10 reads 'FROM node:24.15.0-trixie-slim AS builder'",
+        "Verify memvid-service/Dockerfile line 8 reads 'FROM rust:1.95.0-slim-trixie AS builder' (explicit Trixie suffix)",
+        "Run 'grep -rn bookworm .' from repo root --include=Dockerfile* and confirm zero hits in active Dockerfiles",
+        "Run 'task container:build:frontend' and confirm the build succeeds for linux/amd64 and linux/arm64",
+        "Run 'task container:build:memvid' and confirm the build succeeds for linux/amd64 and linux/arm64",
+        "Run 'bash scripts/test-containers.sh' (default mocked mode) and confirm all 11 checks pass including memvid binary startup and frontend SPA serving",
+        "Run 'MOCK_MEMVID_CLIENT=false bash scripts/test-containers.sh' and confirm Test 7 reports 'Memvid processed real gRPC traffic from api-service' (real ABI proof under Trixie builder + Trixie runtime)",
+        "Run 'trivy image --severity CRITICAL,HIGH --ignore-unfixed --trivyignores .trivyignore localhost/ai-resume-frontend:<version>' and capture the row count; record before/after delta in PR body",
+        "Run 'trivy image --severity CRITICAL,HIGH --ignore-unfixed --trivyignores .trivyignore localhost/ai-resume-memvid:<version>' and capture the row count; record before/after delta in PR body",
+        "Verify .trivyignore contains a CVE-2026-5435 entry referencing GitHub alert #547 with a revisit-2026-08-01 comment",
+        "Push branch and run 'gh workflow run security.yml --ref chore/builder-images-trixie' and confirm both container-scan (frontend) and container-scan (memvid-service) jobs pass",
+        "After merge to main, run 'gh workflow run security.yml --ref main' and confirm Trivy SARIF for ai-resume-memvid no longer surfaces CVE-2026-5435 (suppressed by .trivyignore) and the workflow remains green"
+      ],
+      "passes": false,
+      "dependencies": ["memvid-distroless-debian13"]
     }
   ]
 }

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,7 @@ ARG BUILD_COMMIT=unknown
 # =============================================================================
 # Stage 1: Build React application
 # =============================================================================
-FROM node:24.15.0-bookworm-slim AS builder
+FROM node:24.15.0-trixie-slim AS builder
 
 WORKDIR /app
 

--- a/memvid-service/Dockerfile
+++ b/memvid-service/Dockerfile
@@ -5,7 +5,7 @@ ARG BUILD_COMMIT=unknown
 # Supports amd64 and arm64 architectures
 
 # Stage 1: Build the Rust binary
-FROM rust:1.95.0-slim AS builder
+FROM rust:1.95.0-slim-trixie AS builder
 
 ARG TARGETARCH
 ARG PROTOC_VERSION=28.3


### PR DESCRIPTION
## Summary

Bumps the two Debian-based BUILDER images from Bookworm (Debian 12) to Trixie (Debian 13), aligning the toolchain with the cc-debian13 runtime that landed in #217 (INFRA-091):

| File | Line | Before | After |
| --- | --- | --- | --- |
| `frontend/Dockerfile` | 10 | `node:24.15.0-bookworm-slim` | `node:24.15.0-trixie-slim` |
| `memvid-service/Dockerfile` | 8 | `rust:1.95.0-slim` (unsuffixed Bookworm default) | `rust:1.95.0-slim-trixie` |

The memvid line also gains an explicit `-trixie` suffix per ADR-032, eliminating the unsuffixed-default-tag drift risk (DockerHub will eventually flip `rust:*-slim` to Trixie silently — this pre-empts that). Builder/runtime glibc versions now match (Trixie 2.41 builder + Trixie 2.41 runtime), removing the cross-version forward-compat dance that was implicit before.

This is currency maintenance, not security remediation — no open CVEs drove the bump itself.

## Bundled: disposition of code-scanning alert #547

[Alert #547](https://github.com/schwichtgit/ai-resume/security/code-scanning/547) (`CVE-2026-5435`, glibc deprecated `ns_printrr`/`ns_printrrf`/`fp_nquery` family) surfaced on `library/ai-resume-memvid` after #217 merged. Severity `note`, **fixed version: empty (unfixed upstream in Trixie)**. Added to `.trivyignore` with a `revisit-2026-08-01` comment referencing the alert number, exactly the residual case INFRA-091's clarified acceptance criterion anticipated.

## Trivy delta (after Trixie builders, local scan)

Command (per service):
`trivy image --severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore localhost/ai-resume-<service>:latest`

| Image | Type | HIGH/CRITICAL hits | Notes |
| --- | --- | --- | --- |
| `localhost/ai-resume-frontend` (alpine 3.23.4) | alpine | **0** | Runtime unchanged; bump only affects the build stage, artifacts copied to alpine. |
| `localhost/ai-resume-memvid` (debian 13.4) | debian | **0** | Runtime unchanged from INFRA-091; bump only affects the build stage. |
| `usr/local/bin/memvid-service` | rustbinary | **0** | Compiled on Trixie 2.41, runs on Trixie 2.41 — no symbol-version skew. |

**Net-new HIGH/CRITICAL CVEs introduced: zero.** The IDE Docker DX scanner reported HIGH counts against the upstream `node-trixie-slim` and `rust-slim-trixie` images directly, but those layers are discarded by the multi-stage builds and do not appear in the deployed images.

## Specforge artifacts

- **INFRA-092** added to `.specify/specs/spec.md` under "Container Base Image Currency" with an acceptance criterion enforcing ADR-032 across all Debian-based Dockerfile FROM lines (no unsuffixed tags).
- `.specify/specs/plan.md` Phase 9 split into 9a (shipped INFRA-091) and 9b (this PR) with updated risk matrix and verification strategy.
- `feature_list.json` extended with `builder-images-trixie` (12 testing steps, depends on `memvid-distroless-debian13`).
- Readiness score for the INFRA-092 delta: 94.75 / 100.

## Test plan

- [x] `task container:build:frontend` succeeds (multi-arch `linux/amd64` + `linux/arm64` manifest)
- [x] `task container:build:memvid` succeeds (multi-arch manifest)
- [x] `bash scripts/test-containers.sh` (default mocked mode) — all 11 checks pass
- [x] `MOCK_MEMVID_CLIENT=false bash scripts/test-containers.sh` (real api↔memvid gRPC under Trixie builder + Trixie runtime) — all 11 checks pass
- [x] Local Trivy scans on both rebuilt images — 0 HIGH/CRITICAL on frontend (alpine), memvid (debian), and rustbinary
- [ ] Post-merge: `gh workflow run security.yml --ref main` confirms the SARIF on `main` does not surface any new HIGH/CRITICAL CVEs and `.trivyignore` correctly suppresses CVE-2026-5435 (alert #547)

## Out of scope

- `docs/DEPLOYMENT.md` line 26 carries a stale "Python slim-bookworm" reference for api-service that predates the UBI 10 migration. Unrelated to INFRA-092; flagged here for a separate doc fix.
- `CLAUDE.md` line 8 says "Rust 1.93" — also stale (current is 1.95.0). Unrelated to the suffix-pinning work; same separate doc fix.

Implements INFRA-092 per the existing ADR-032.