### PR TITLE
docs: release 0.1.0-alpha.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.17] - 2026-05-01
+
+### Security
+
+- Memvid runtime base bumped from `gcr.io/distroless/cc-debian12:nonroot` (Debian 12 Bookworm, glibc 2.36) to `gcr.io/distroless/cc-debian13:nonroot` (Debian 13 Trixie, glibc 2.41) (#217). Improves the security posture of `library/ai-resume-memvid` against five glibc CVEs flagged by Trivy: `CVE-2026-4046` (alert #539, iconv DoS), `CVE-2026-4437` (#540, DNS response parsing), `CVE-2026-4438` (#541, gethostbyaddr), `CVE-2026-5450` (#543, scanf %mc overflow), `CVE-2026-5928` (#544, ungetwc disclosure). All five are unfixed upstream in either Bookworm or Trixie; the bump to Trixie 2.41 picks up the upstream mitigations Debian's security team applied, downgrading them from HIGH to MEDIUM. The five alerts remain `open` on the security tab as a SARIF state-machine artifact (severity downgrade is not auto-resolved by GitHub); a cleanup PR will codify them in `.trivyignore` with `revisit-YYYY-MM-DD` comments. Pins the explicit `-debianN` distroless suffix per ADR-032 to eliminate silent default-tag drift.
+- `.trivyignore` retired the obsolete `CVE-2026-28390` libssl3 suppression (libssl3 is absent from the cc-debian13 runtime) (#217).
+- `.trivyignore` extended to suppress `CVE-2026-5435` (alert #547, glibc deprecated `ns_printrr`/`ns_printrrf`/`fp_nquery` family, severity `note`, unfixed upstream in Trixie) with a `revisit-2026-08-01` comment (#218). GitHub code-scanning alert #547 auto-transitioned to `fixed` after the post-merge SARIF reconcile.
+
+### Changed
+
+- Frontend builder bumped from `node:24.15.0-bookworm-slim` to `node:24.15.0-trixie-slim` (#218).
+- Memvid builder bumped from `rust:1.95.0-slim` (unsuffixed Bookworm default) to `rust:1.95.0-slim-trixie` (#218). The explicit `-trixie` suffix eliminates the unsuffixed-default-tag drift risk per ADR-032 and aligns builder/runtime glibc versions (Trixie 2.41 builder + Trixie 2.41 runtime, no cross-version forward-compat dance).
+- `scripts/test-containers.sh` gained shell-overridable `MOCK_MEMVID`, `MOCK_MEMVID_CLIENT`, `MOCK_OPENROUTER`, and `RUST_LOG` env vars (#218); defaults preserve historical fully-mocked behaviour. Real api↔memvid gRPC verification now possible via `MOCK_MEMVID_CLIENT=false bash scripts/test-containers.sh`. Also corrected the stale Test 7 assertion (was grepping memvid logs for a `Search` RPC log line; the chat handler has called `Ask` since re-ranking landed).
+
+### Documentation
+
+- Tech-stack reference in the project guide updated from `Rust 1.93` to `Rust 1.95` to match the alpha.16 builder bump in #215.
+- `docs/DEPLOYMENT.md`: corrected the `api-service` arch-support row (was claiming `Python slim-bookworm multi-arch base`, which has not been accurate since the alpha.15 migration to `ubi10/ubi-micro` runtime + `rockylinux/rockylinux:10-minimal` builder).
+
+### Specforge
+
+- New features `INFRA-091` (Memvid Distroless Base Currency) and `INFRA-092` (Builder Image Currency, Bookworm to Trixie) added to `.specify/specs/spec.md` under "Container Base Image Currency".
+- New `ADR-032` (Pin Distroless Image with Explicit `-debianN` Suffix) and Phase 9 wrapper added to `.specify/specs/plan.md`.
+- `feature_list.json` extended with `memvid-distroless-debian13` and `builder-images-trixie` entries.
+
 ## [0.1.0-alpha.16] - 2026-04-26
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 
 **Description:** Polyglot web application enabling recruiters to query a candidate's experience via AI chat with semantic search retrieval
-**Tech Stack:** TypeScript (React 19), Python 3.12 (FastAPI), Rust 1.93 (memvid gRPC)
+**Tech Stack:** TypeScript (React 19), Python 3.12 (FastAPI), Rust 1.95 (memvid gRPC)
 **Repository:** <https://github.com/schwichtgit/ai-resume>
 
 This is an interactive AI-powered resume site built with Vite, React, TypeScript, shadcn/ui, and Tailwind CSS. The site showcases a candidate's experience with an AI chat interface that answers questions about their background, an honest fit assessment tool, and detailed experience cards.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -20,11 +20,11 @@ The ingest service runs once to build the `.mv2` vector database file from
 
 All service images build and run on both **amd64** and **arm64** architectures.
 
-| Service        | amd64 | arm64 | Notes                                       |
-| -------------- | ----- | ----- | ------------------------------------------- |
-| frontend       | Yes   | Yes   | Alpine + OpenResty available on both arches |
-| api-service    | Yes   | Yes   | Python slim-bookworm multi-arch base        |
-| memvid-service | Yes   | Yes   | Rust cross-compiles via `--platform` flag   |
+| Service        | amd64 | arm64 | Notes                                                     |
+| -------------- | ----- | ----- | --------------------------------------------------------- |
+| frontend       | Yes   | Yes   | Alpine + OpenResty available on both arches               |
+| api-service    | Yes   | Yes   | UBI 10 micro runtime + Rocky Linux 10 builder, multi-arch |
+| memvid-service | Yes   | Yes   | Rust cross-compiles via `--platform` flag                 |
 
 The memvid-service Dockerfile uses `ARG TARGETARCH` for platform-aware builds.
 The frontend and api-service use base images that natively support both architectures.


### PR DESCRIPTION
## Summary

Release notes for `0.1.0-alpha.17`. Doc-only — covers all version-changing PRs landed since alpha.16.

### Included

- **#217** — INFRA-091: memvid runtime base bumped from `gcr.io/distroless/cc-debian12:nonroot` (Bookworm, glibc 2.36) to `gcr.io/distroless/cc-debian13:nonroot` (Trixie, glibc 2.41). Drives Trixie's upstream mitigations for five glibc CVEs (alerts #539-541, #543-544: CVE-2026-4046/4437/4438/5450/5928), downgrading them HIGH→MEDIUM. Also retires the obsolete `CVE-2026-28390` libssl3 suppression in `.trivyignore`. Pins explicit `-debianN` distroless suffix per ADR-032.
- **#218** — INFRA-092: frontend builder `node:24.15.0-bookworm-slim` → `node:24.15.0-trixie-slim`, memvid builder `rust:1.95.0-slim` (unsuffixed) → `rust:1.95.0-slim-trixie`. Aligns builder/runtime glibc to Trixie 2.41, eliminates unsuffixed-default-tag drift risk. Also dispositions alert #547 (CVE-2026-5435, glibc deprecated `ns_printrr` family, severity `note`, unfixed upstream) via `.trivyignore` (auto-transitioned to `fixed` after post-merge SARIF reconcile). Smoke test `scripts/test-containers.sh` gained shell-overridable `MOCK_*` env vars and a corrected Test 7 assertion (chat handler uses Ask RPC, not Search, since re-ranking landed).

### Doc corrections

Stale references swept in alongside the release:

- Tech-stack reference: `Rust 1.93` → `Rust 1.95` (caught up with the alpha.16 builder bump in #215).
- `docs/DEPLOYMENT.md` api-service arch-support row: `Python slim-bookworm multi-arch base` → `UBI 10 micro runtime + Rocky Linux 10 builder, multi-arch` (caught up with the alpha.15 migration in #197).

### Specforge artifacts

Both feature PRs ran the full cpf:specforge workflow (spec → clarify → plan → features → analyze) before implementation. Net additions: `INFRA-091`, `INFRA-092`, `ADR-032` (distroless suffix-pinning policy), Phase 9 wrapper, two `feature_list.json` entries.

## Deferred follow-ups

- **Cleanup PR for stuck Trivy alerts** (#539-541, #543-544, #548): add each to `.trivyignore` with a `revisit-YYYY-MM-DD` comment and the GitHub alert number, citing the Trixie severity downgrade and unfixed-upstream status. SARIF reconcile will auto-transition them to `fixed` (confirmed pattern from how alert #547 closed after #218).
- **Manual dismissal for alerts #545, #546** (CodeQL `py/bind-socket-all-network-interfaces` on `api-service/start.py`): `wont-fix` with rationale citing Constitution §4 (network zone isolation) + reverse-proxy boundary; pre-existing pattern, not introduced by either #217 or #218. Document in `docs/SECURITY.md`.
- **Optional**: harden `.github/workflows/security.yml` to filter SARIF uploads by severity, so future severity-downgrade situations don't accumulate stuck alerts on the security tab.

## Test plan

- [x] CHANGELOG entry follows Keep-a-Changelog format and includes both merged PRs since alpha.16
- [x] Doc corrections do not change behaviour
- [x] Diff is doc-only (CHANGELOG, project guide, DEPLOYMENT)
- [ ] CI green on this branch (markdownlint, prettier)
- [ ] Tag `v0.1.0-alpha.17` after merge