### PR TITLE
chore(security): clean up stale code-scanning alerts

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -7,4 +7,10 @@
 #
 # Reference: https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/#by-finding-ids
 
+CVE-2026-4046  # libc6 iconv() DoS via specific charsets. Originally HIGH on Bookworm, MEDIUM on Trixie. Unfixed upstream. GitHub alert #539. Revisit 2026-08-01.
+CVE-2026-4437  # libc6 incorrect DNS response parsing via crafted server response. MEDIUM on Trixie. Unfixed upstream. GitHub alert #540. Revisit 2026-08-01.
+CVE-2026-4438  # libc6 invalid DNS hostname returned via gethostbyaddr. MEDIUM on Trixie. Unfixed upstream. GitHub alert #541. Revisit 2026-08-01.
 CVE-2026-5435  # libc6 deprecated ns_printrr/ns_printrrf/fp_nquery family in glibc 2.41 (Trixie). Unfixed upstream. GitHub alert #547, severity note. Revisit 2026-08-01.
+CVE-2026-5450  # libc6 heap buffer overflow in scanf %mc with large width. MEDIUM on Trixie. Unfixed upstream. GitHub alert #543. Revisit 2026-08-01.
+CVE-2026-5928  # libc6 information disclosure or DoS via ungetwc with specific wide-char encodings. MEDIUM on Trixie. Unfixed upstream. GitHub alert #544. Revisit 2026-08-01.
+CVE-2026-6238  # libc6 (glibc 2.41-12+deb13u2) note-severity finding, no fixed version published. GitHub alert #548. Revisit 2026-08-01.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -201,10 +201,12 @@ Binding to `0.0.0.0` is intentional and safe in this containerized deployment. T
 
 **Code Scanning Dismissal:**
 
-- Alert #2: <https://github.com/schwichtgit/ai-resume/security/code-scanning/2>
-- Alert #3: <https://github.com/schwichtgit/ai-resume/security/code-scanning/3>
-- Reason: `wont-fix` - Intentional design, safe in containerized deployment
-- Reviewed: 2026-02-06
+- Original alerts #2 and #3 dismissed on 2026-02-06; subsequently auto-fixed by CodeQL state-machine churn
+- Re-detected as alerts #545 and #546 in the post-2026-05-01 scan after a CodeQL ruleset update on the same code pattern
+- Alert #545: <https://github.com/schwichtgit/ai-resume/security/code-scanning/545>
+- Alert #546: <https://github.com/schwichtgit/ai-resume/security/code-scanning/546>
+- Reason: `wont-fix` -- Intentional design, safe in containerized deployment (rationale unchanged from original 2026-02-06 review; see "Why This Is Safe" above)
+- Reviewed: 2026-05-01
 
 ### Volume Mounts
 
@@ -305,6 +307,39 @@ The alert appears to be triggered by pattern matching on "random" operations in 
 
 **Status:** Fixed (enhanced implementation with better documentation)
 **Reviewed:** 2026-02-06
+
+#### Trivy: glibc Trixie unfixed-upstream batch (Alerts #539, #540, #541, #543, #544, #547, #548)
+
+**Alerts:**
+
+- [#539](https://github.com/schwichtgit/ai-resume/security/code-scanning/539) -- `CVE-2026-4046` (libc6 iconv() DoS via specific charsets)
+- [#540](https://github.com/schwichtgit/ai-resume/security/code-scanning/540) -- `CVE-2026-4437` (libc6 incorrect DNS response parsing via crafted server response)
+- [#541](https://github.com/schwichtgit/ai-resume/security/code-scanning/541) -- `CVE-2026-4438` (libc6 invalid DNS hostname returned via gethostbyaddr)
+- [#543](https://github.com/schwichtgit/ai-resume/security/code-scanning/543) -- `CVE-2026-5450` (libc6 heap buffer overflow in scanf `%mc` with large width)
+- [#544](https://github.com/schwichtgit/ai-resume/security/code-scanning/544) -- `CVE-2026-5928` (libc6 information disclosure or DoS via ungetwc with specific wide-char encodings)
+- [#547](https://github.com/schwichtgit/ai-resume/security/code-scanning/547) -- `CVE-2026-5435` (libc6 deprecated `ns_printrr`/`ns_printrrf`/`fp_nquery` family, severity note)
+- [#548](https://github.com/schwichtgit/ai-resume/security/code-scanning/548) -- `CVE-2026-6238` (libc6 note-severity finding, no fix published)
+
+**Tool:** Trivy
+**Path:** `library/ai-resume-memvid` (the deployed memvid container image)
+**Package:** `libc6` (glibc 2.41-12+deb13u2, Debian 13 Trixie)
+
+**Disposition:** All seven CVEs are suppressed via `.trivyignore`. Trivy filters them out of the SARIF upload, so GitHub's code-scanning state machine auto-transitions each alert to `fixed` on the next Security Scan run on `main` (this pattern was confirmed empirically when alert #547 closed automatically after #218 added a single-CVE entry).
+
+**Rationale:**
+
+- All seven CVEs are reported with `Fixed Version: (empty)` -- **unfixed upstream** by the Debian Trixie security team. There is no patch to apply.
+- Five of them (#539-541, #543-544) were originally registered as HIGH (`warning`) severity against the Bookworm glibc 2.36 baseline. The bump to Trixie's glibc 2.41 (#217, INFRA-091) picked up Debian's upstream mitigations, downgrading them to MEDIUM. The constitution's §6 SLA ("critical/high CVEs patched within 7 days") is satisfied in spirit -- we have applied the latest available upstream mitigation.
+- Two of them (#547, #548) are `note`-severity findings that emerged in post-bump scans (deprecated API warnings, no exploit path).
+- Every `.trivyignore` entry carries a `Revisit 2026-08-01` comment. Trixie security-team updates between now and that date should retire several of the entries automatically; remaining suppressions get re-evaluated and re-justified each quarter.
+
+**Container security context:**
+
+The `memvid-service` runtime is a distroless `cc-debian13:nonroot` image: only libc6, libgcc, and libstdc++ from the OS layer; no shell, no package manager, no network tooling. The compiled Rust binary does not call the affected glibc entry points -- `ns_printrr*` family is a syslog-related deprecated API not used by tonic/tokio; `ungetwc`, `iconv`, and `scanf %mc` are unused by the gRPC service paths. The deployed image runs as `nonroot` (UID 65534) inside an isolated container network namespace, behind a reverse proxy. The reverse proxy enforces TLS, authentication, and rate limiting; the container is not directly reachable from the internet.
+
+**Status:** Suppressed via `.trivyignore`
+**Reviewed:** 2026-05-01
+**Revisit:** 2026-08-01
 
 ## Dependency Security
 


### PR DESCRIPTION
## Summary

Codifies the disposition of 7 stuck Trivy alerts on `library/ai-resume-memvid` and refreshes the documentation for the 2 CodeQL `py/bind-socket-all-network-interfaces` alerts. The Trivy alerts auto-transition to `fixed` after merge; the CodeQL alerts get a manual UI dismissal post-merge so the dismissal comment can reference rationale on `main`.

## Trivy alerts suppressed via `.trivyignore`

All seven CVEs report `Fixed Version: (empty)` — **unfixed upstream** by the Debian Trixie security team.

| Alert | CVE | Description | Severity (post-Trixie) |
| --- | --- | --- | --- |
| [#539](https://github.com/schwichtgit/ai-resume/security/code-scanning/539) | CVE-2026-4046 | libc6 iconv() DoS via specific charsets | MEDIUM (was HIGH on Bookworm) |
| [#540](https://github.com/schwichtgit/ai-resume/security/code-scanning/540) | CVE-2026-4437 | libc6 incorrect DNS response parsing | MEDIUM (was HIGH on Bookworm) |
| [#541](https://github.com/schwichtgit/ai-resume/security/code-scanning/541) | CVE-2026-4438 | libc6 invalid DNS hostname via gethostbyaddr | MEDIUM (was HIGH on Bookworm) |
| [#543](https://github.com/schwichtgit/ai-resume/security/code-scanning/543) | CVE-2026-5450 | libc6 heap buffer overflow in scanf `%mc` | MEDIUM (was HIGH on Bookworm) |
| [#544](https://github.com/schwichtgit/ai-resume/security/code-scanning/544) | CVE-2026-5928 | libc6 ungetwc disclosure or DoS | MEDIUM (was HIGH on Bookworm) |
| [#547](https://github.com/schwichtgit/ai-resume/security/code-scanning/547) | CVE-2026-5435 | libc6 deprecated `ns_printrr` family | note (already suppressed in #218; retained) |
| [#548](https://github.com/schwichtgit/ai-resume/security/code-scanning/548) | CVE-2026-6238 | libc6 note-severity finding | note |

Each `.trivyignore` entry carries a `Revisit 2026-08-01` comment + the GitHub alert number citation. Quarterly re-evaluation; Trixie security-team patches between now and then will retire entries automatically.

## Why suppression is the right call

- The bump to Trixie glibc 2.41 (#217, INFRA-091) already picked up Debian's upstream mitigations — the five originally-HIGH alerts are now MEDIUM. Constitution §6 ("critical/high CVEs patched within 7 days") is satisfied in spirit.
- The compiled Rust binary in `memvid-service` does not call the affected glibc entry points: `ns_printrr*` family is a syslog deprecated API not used by tonic/tokio; `iconv`, `ungetwc`, and `scanf %mc` are unused on the gRPC service paths.
- The runtime is `gcr.io/distroless/cc-debian13:nonroot` — only libc6 + libgcc + libstdc++; no shell, no package manager, no network tooling. Container runs as nonroot (UID 65534) inside an isolated network namespace, behind a reverse proxy enforcing TLS, auth, and rate limits.

## SARIF auto-transition mechanism

`.github/workflows/security.yml` already passes `trivyignores: '.trivyignore'` to both the SARIF upload step and the gate step. Trivy filters suppressed CVEs out of the SARIF before generation, so GitHub's code-scanning state machine sees them as "no longer reported" and auto-transitions each to `fixed` on the next Security Scan run on `main`. This pattern was confirmed empirically when alert #547 closed automatically after #218 added a single-CVE entry.

## CodeQL alerts (#545, #546) — separate UI dismissal

[#545](https://github.com/schwichtgit/ai-resume/security/code-scanning/545) and [#546](https://github.com/schwichtgit/ai-resume/security/code-scanning/546) are CodeQL `py/bind-socket-all-network-interfaces` findings on `api-service/start.py`. CodeQL alerts cannot be suppressed via `.trivyignore`. The rationale is already documented in `docs/SECURITY.md` under "Bind Address Security (0.0.0.0)" — this PR refreshes that section to point at the current alert numbers (the original #2/#3 were auto-fixed by CodeQL state-machine churn and the same code pattern was re-detected with new alert numbers after a CodeQL ruleset update).

After this PR merges, the dismissals will be applied via:

```bash
gh api --method PATCH repos/schwichtgit/ai-resume/code-scanning/alerts/545 \
  -f state=dismissed -f dismissed_reason=wont-fix \
  -f dismissed_comment='Intentional containerized-service pattern; rationale in docs/SECURITY.md "Bind Address Security (0.0.0.0)" section.'

gh api --method PATCH repos/schwichtgit/ai-resume/code-scanning/alerts/546 \
  -f state=dismissed -f dismissed_reason=wont-fix \
  -f dismissed_comment='Intentional containerized-service pattern; rationale in docs/SECURITY.md "Bind Address Security (0.0.0.0)" section.'
```

## Test plan

- [x] `.trivyignore` syntax valid; each entry has `# rationale + alert + revisit-date` comment
- [x] `docs/SECURITY.md` builds (markdownlint clean)
- [x] Doc references match current alert numbers
- [ ] Post-merge: `gh workflow run security.yml --ref main` triggers a Security Scan
- [ ] Post-merge: alerts #539, #540, #541, #543, #544, #547, #548 transition to `fixed` after the SARIF reconcile
- [ ] Post-merge: alerts #545 and #546 dismissed via `gh api PATCH` with the rationale comment above
- [ ] Final state: zero open code-scanning alerts on the repo

## Out of scope

- No workflow change. `.github/workflows/security.yml` is already correct (it filters `.trivyignore` at SARIF emission, not just at the gate). Earlier in this thread I considered tightening severity filtering on SARIF uploads, but that would lose visibility into MEDIUM/LOW surveillance findings — a downgrade, not an upgrade.

Pairs with INFRA-091 (#217) and INFRA-092 (#218); finishes the security-tab cleanup arc that started with the cc-debian13 runtime bump.