### PR TITLE
fix(test): correct stale filename assertion in memvid real searcher test

### DIFF
--- a/memvid-service/src/memvid/real.rs
+++ b/memvid-service/src/memvid/real.rs
@@ -472,7 +472,7 @@ mod tests {
 
         assert!(searcher.is_ready());
         assert!(searcher.frame_count() > 0);
-        assert!(searcher.memvid_file().contains("resume.mv2"));
+        assert_eq!(searcher.memvid_file(), mv2_path);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes the lone failing unit test in `memvid-service`: `memvid::real::tests::test_real_searcher_loads_valid_file`.

## Root cause

PR #118 (`fix(test): isolate .mv2 file access for memvid exclusive locking`) introduced `isolated_mv2()` to copy the production `.mv2` into a tempdir as `test.mv2` so each test holds an exclusive lock. The PR description explicitly stated:

> Temp copies use `test.mv2` (not the production filename) to avoid hardcoding path-specific assumptions in tests.

But the assertion at `memvid-service/src/memvid/real.rs:475` was missed in that rewrite and continued to require the substring `"resume.mv2"` in the path:

```rust
assert!(searcher.memvid_file().contains("resume.mv2"));
```

Once `isolated_mv2()` started returning paths ending in `test.mv2`, the assertion became permanently false. Has been failing on `main` ever since #118 merged on 2026-03-15.

## Fix

Replace the substring check with `assert_eq!` against the actual path passed to `RealSearcher::new()`. This is also a stronger semantic test: `memvid_file()` is supposed to return what was configured, so checking exact equality is the correct invariant.

```rust
assert_eq!(searcher.memvid_file(), mv2_path);
```

## Verification

- [x] `cargo test --lib memvid::real::tests` -- 11/11 passing (was 10/11)
- [x] `cargo test` (full suite) -- 27/27 passing
- [x] `cargo clippy --all-targets -- -D warnings` -- clean
- [x] Reproduced the failure on `origin/main` before applying the fix; reproduced the pass with the fix applied