### PR TITLE
fix(memvid): add explicit USER nonroot to satisfy release-gate

### DIFF
--- a/memvid-service/Dockerfile
+++ b/memvid-service/Dockerfile
@@ -59,7 +59,7 @@ ARG BUILD_VERSION
 ARG BUILD_COMMIT
 RUN printf '{"version":"%s","commit":"%s"}\n' "${BUILD_VERSION}" "${BUILD_COMMIT}" > /app/VERSION
 
-# Stage 2: Distroless runtime (glibc 2.41, UID 65534 nonroot)
+# Stage 2: Distroless runtime (glibc 2.41, UID 65532 nonroot)
 FROM gcr.io/distroless/cc-debian13:nonroot
 
 # Copy binary from builder
@@ -71,5 +71,7 @@ EXPOSE 50051
 
 # Expose Prometheus metrics port
 EXPOSE 9090
+
+USER nonroot
 
 ENTRYPOINT ["/usr/local/bin/memvid-service"]


### PR DESCRIPTION
## Summary

Fixes the failing `release-gate / Outcome tests -- Container Config` step on `main` ([example failing run](https://github.com/schwichtgit/ai-resume/actions/runs/25331513988/job/74267430374)).

## Root cause

`scripts/test-outcome-containers.sh` (Check 3) greps each service Dockerfile for a literal `^USER` line:

```bash
for dir in frontend api-service memvid-service; do
    if grep -q "^USER" "$dir/Dockerfile"; then
        echo "  PASS: \$dir uses non-root USER"
    else
        echo "  FAIL: \$dir missing USER directive"
        FAIL=\$((FAIL + 1))
    fi
done
```

PR #218 (alpha.17 / INFRA-091) switched the memvid runtime stage to `gcr.io/distroless/cc-debian13:nonroot`. The `:nonroot` distroless tag already runs as the nonroot user (UID 65532) by default, so no explicit `USER` directive was added. The script's simple grep didn't account for that.

Result: release-gate has been failing on every push to `main` since #218 merged. PR #229 (Dependabot rollup) and PR #230 (memvid test fix) inherited the failure.

## Fix

Add `USER nonroot` to `memvid-service/Dockerfile`'s runtime stage. Semantically a no-op against the `:nonroot` base, but documents the security posture inline and keeps the simple grep-based gate green.

Also corrected the existing comment: distroless `:nonroot` runs as UID **65532** (named `nonroot`), not 65534 (`nobody`).

## Verification

- [x] `bash scripts/test-outcome-containers.sh` -- 9 passed, 0 failed (was 8 passed, 1 failed)
- [x] Diff is two lines (one new directive, one corrected comment)
- [x] No image rebuild required for runtime semantics

## Follow-up (not in this PR)

The grep-based check is brittle: a future Dockerfile that uses a different `:nonroot`-style base would also fail it without changing security posture. Worth refining the script to also accept `:nonroot` distroless bases as a valid signal. Filed as a follow-up rather than included here to keep the fix surgical.