### PR TITLE
ci: reclaim disk space on amd64 ingest container build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,6 +643,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # The ingest container drags in the full torch/nvidia CUDA wheel stack via
+      # sentence-transformers, which routinely exhausts the ~14 GB of free disk
+      # on the ubuntu-latest amd64 runner during `uv sync`. Reclaim ~30 GB by
+      # purging preinstalled toolchains we do not need here. Arm runner has
+      # more headroom and skips this step. Tracked: alpha.18 post-mortem.
+      - name: Free disk space on amd64 ingest runner
+        if: matrix.image == 'ingest' && matrix.platform == 'amd64'
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+
       - name: Install cosign
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
         uses: sigstore/cosign-installer@v3


### PR DESCRIPTION
## Summary

PR #249's release build hit out-of-disk on `container-build (ingest, amd64)` (run 25875263867, job 76040698330):

\`\`\`
2026-05-14T17:40:27.5164773Z ##[warning]You are running out of disk space.
The runner will stop working when the machine runs out of disk space.
Free space left: 0 MB

Error: ... uv sync ...: io: read/write on closed pipe
##[error]Process completed with exit code 125
\`\`\`

The ingest service transitively pulls the full **torch + nvidia CUDA wheel stack** (`nvidia-cublas`, `nvidia-cudnn`, `nvidia-cusparselt`, etc.) via `memvid-sdk` -> `sentence-transformers`. Several GB just for CUDA wheels. The ~14 GB free on the hosted `ubuntu-latest` runner gets consumed by the rocky-linux/ubi-micro build-stage images, the uv cache mount populating the CUDA wheels, and the final layer being committed.

## Fix

Add `jlumbroso/free-disk-space@v1.3.1` to reclaim ~30 GB by purging preinstalled tool-cache, Android SDK, .NET, and Haskell that this build does not need. Gated to `ingest` + `amd64` because:

- `arm64` runs on `ubuntu-24.04-arm` which has more headroom and squeaked through on the failing run
- `frontend`, `api`, `memvid` don't pull torch and aren't disk-constrained

Skipped the heavier `large-packages: true` and `swap-storage: true` options — they're slow (~2-3 min each) and unnecessary here; the smaller purges already reclaim ~30 GB.

## Follow-up

A second PR will pin ingest to the CPU-only torch wheel index (`https://download.pytorch.org/whl/cpu`) so the NVIDIA CUDA wheels never enter the image. That's the durable structural fix; this PR is the immediate unblock so the next release tag doesn't trip the same wall.

## Test plan

- [ ] CI green; specifically `container-build (ingest, amd64)` succeeds with the freed-up disk
- [ ] Free-disk-space step reports ~30 GB reclaimed in its job log
- [ ] Image size unchanged (we're just freeing host disk, not slimming the image)