### PR TITLE
build(deps): bump memvid otel stack 0.31->0.32 (closes #239 #241 #243)

### DIFF
--- a/memvid-service/Cargo.lock
+++ b/memvid-service/Cargo.lock
@@ -1873,9 +1873,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1887,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -1914,14 +1914,14 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1932,15 +1932,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.3",
  "thiserror 2.0.18",
  "tokio",
@@ -2426,9 +2427,9 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -2444,9 +2445,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",
@@ -3306,6 +3304,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3401,9 +3410,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/memvid-service/Cargo.toml
+++ b/memvid-service/Cargo.toml
@@ -22,10 +22,10 @@ serde_json = "1.0"
 # Observability
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-tracing-opentelemetry = "0.32.1"
-opentelemetry = "0.31"
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }
+tracing-opentelemetry = "0.33"
+opentelemetry = "0.32"
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic"] }
 metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
 


### PR DESCRIPTION
## Summary

Bumps the memvid-service OpenTelemetry crates to 0.32 plus the paired `tracing-opentelemetry` 0.33 bump that Dependabot doesn't surface.

Previously parked (see prior rollup #260) because `tracing-opentelemetry 0.32.1` still depended on `opentelemetry 0.31`, which would have produced a dual-version graph and a `Tracer` trait mismatch. **`tracing-opentelemetry 0.33.0` shipped to crates.io on 2026-05-18** and pins `opentelemetry ^0.32.0`, so the triple now resolves cleanly.

## Changes

- `opentelemetry` 0.31 -> 0.32 (closes #239)
- `opentelemetry-otlp` 0.31 -> 0.32 (closes #241)
- `opentelemetry_sdk` 0.31 -> 0.32 (closes #243)
- `tracing-opentelemetry` 0.32.1 -> 0.33 (manual; not in Dependabot)

`cargo update -p opentelemetry -p opentelemetry-otlp -p opentelemetry_sdk -p tracing-opentelemetry` also incidentally bumped:

- `opentelemetry-http` 0.31 -> 0.32
- `opentelemetry-proto` 0.31 -> 0.32
- `reqwest` 0.12 -> 0.13 (transitive via opentelemetry-otlp)
- adds `tonic-types` 0.14.6 (new transitive)

## Code changes

None. The API surface used by `src/otel.rs` is forward-compatible between 0.31 and 0.32:

- `opentelemetry::trace::TracerProvider`
- `opentelemetry::KeyValue`
- `opentelemetry_otlp::SpanExporter::builder().with_tonic().with_endpoint().build()`
- `opentelemetry_otlp::WithExportConfig`
- `opentelemetry_sdk::trace::SdkTracerProvider::builder().with_batch_exporter().with_resource().build()`
- `opentelemetry_sdk::trace::SdkTracer` (return type)
- `opentelemetry_sdk::Resource::builder_empty().with_attributes().build()`
- `tracing_opentelemetry::OpenTelemetryLayer::new(tracer)`

## Local verification

- [x] `cargo check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` -- **61 passed, 0 failed, 2 ignored**

## Test plan

- [ ] CI green (memvid-service matrix job)
- [ ] Container build amd64 + arm64 succeeds (no SBOM regressions from new transitive `tonic-types`)
- [ ] Smoke-test trace export against a local OTLP collector in dev to confirm runtime behaviour is unchanged (the unit tests only cover layer construction; they don't exercise the network path)
- [ ] Dependabot closes #239, #241, #243 automatically once merged