### PR TITLE
fix(api): copy libgcc_s versioned target so its symlink resolves

### DIFF
--- a/api-service/Dockerfile
+++ b/api-service/Dockerfile
@@ -70,6 +70,7 @@ RUN mkdir -p /python-runtime/usr/bin \
     libuuid.so* \
     libstdc++.so* \
     libgcc_s.so* \
+    'libgcc_s-*.so*' \
     ; do \
     find /usr/lib64 -maxdepth 1 -name "$lib" -exec cp -a {} /python-runtime/usr/lib64/ \; 2>/dev/null; \
     done


### PR DESCRIPTION
## Summary

The api container's startup fails as of the recent ubi-micro rebase:

```
ImportError: libgcc_s.so.1: cannot open shared object file: No such file or directory
  File "/app/.venv/lib64/python3.12/site-packages/pydantic_core/__init__.py", line 8
    from ._pydantic_core import (...)
```

This is a **latent Dockerfile bug exposed by a base-image bump**, NOT a regression from #260 or #261. Verified by rebuilding with the alpha.18 lockfile against today's `registry.access.redhat.com/ubi10/ubi-micro` — same failure.

## Root cause

`api-service/Dockerfile` stages shared libraries from `rockylinux/rockylinux:10-minimal` into `/python-runtime/usr/lib64/` via a `for lib in …; do find … -name "$lib" -exec cp -a {} … \; done` loop. The glob `libgcc_s.so*` matches the **symlink** `/usr/lib64/libgcc_s.so.1`, but NOT the **versioned target** `/usr/lib64/libgcc_s-14-<snapshot>.so.1` (because the `-14-` infix breaks the `.so*` glob, unlike `libstdc++.so.6` + `libstdc++.so.6.0.33` which both match `libstdc++.so*`).

Previously this worked by **coincidence**: rocky-10-minimal and ubi-micro shipped the same libgcc snapshot, so the runtime base happened to have a versioned file matching what the staged symlink pointed at. With this week's ubi-micro rebase, rocky is on `libgcc-14-20250617` (the symlink target) while ubi-micro is on `libgcc-14-20251022`. The symlink now dangles in the final image, and any native extension that dynamically links `libgcc_s.so.1` (pydantic_core, grpcio, etc.) fails to load.

## Fix

Add a second glob `'libgcc_s-*.so*'` to the find loop so the versioned filename is also staged. Single-line diff.

```diff
     libstdc++.so* \
     libgcc_s.so* \
+    'libgcc_s-*.so*' \
     ; do \
```

## Verification (local, linux/arm64)

```
# Pre-fix:
$ podman run --rm api-test:alpha19
ImportError: libgcc_s.so.1: cannot open shared object file: No such file or directory

# Post-fix:
$ podman run --rm --entrypoint /app/.venv/bin/python api-test:fix \
    -c "import pydantic_core; print(pydantic_core.__version__)"
2.46.4

# Symlink state in fixed image:
libgcc_s-14-20250617.so.1: file, size=136936  (rocky snapshot — newly staged via this fix)
libgcc_s-14-20251022.so.1: file, size=136952  (ubi-micro snapshot — was always present)
libgcc_s.so.1: SYMLINK -> libgcc_s-14-20250617.so.1 (target exists: True)
```

## Release impact

- `v0.1.0-alpha.19` tag was published and then deleted earlier today (`git push --delete origin v0.1.0-alpha.19`) because of this regression.
- The alpha.19 release-doc PR (#262) and CHANGELOG entry remain on `main` — the listed dep bumps are still what shipped; only the broken container build is being fixed.
- On merge of this PR, re-cut the `v0.1.0-alpha.19` annotated tag pointing at the new `main` HEAD (which is the prior release-doc commit + this Dockerfile fix). No CHANGELOG change needed.

## Follow-up (NOT in this PR)

The IDE's Red Hat Dependency Analytics plugin flagged a HIGH-severity CSAF vulnerability on `registry.access.redhat.com/ubi10/ubi-micro` (the image we're FROM at line 80). Out of scope for this hotfix — track separately.

## Test plan

- [ ] CI green across all matrix jobs (in particular `container-build (api, amd64)` and `(api, arm64)`)
- [ ] Release-gate (cosign attestation, SBOM, Trivy) clean on the merge commit
- [ ] After merge, re-cut `v0.1.0-alpha.19` annotated tag on the new main HEAD