### PR TITLE
docs: release 0.1.0-alpha.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-alpha.19] - 2026-05-22
+## [0.1.0-alpha.20] - 2026-05-22
+
+> Supersedes the withdrawn `0.1.0-alpha.19` tag, which was published twice and withdrawn twice on 2026-05-21/2026-05-22. The first tag was withdrawn after the api container failed to start with `ImportError: libgcc_s.so.1: cannot open shared object file`; the re-cut tag (which included the libgcc Dockerfile fix in #263) was withdrawn after the release workflow's signature-verify job failed on `ai-resume-ingest` because release-validate raced two concurrent CI runs on the same SHA and selected the dev-versioned `push`-event run instead of the tag-event run. Cutting fresh as alpha.20 from current `main` HEAD avoids reusing a burned tag.
 
 ### Changed
 
@@ -24,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Manual paired bump: `tracing-opentelemetry` 0.32.1 → 0.33 (no Dependabot PR — `tracing-opentelemetry 0.33.0` published to crates.io 2026-05-18, pins `opentelemetry ^0.32.0`, which unblocked the previously parked triple from alpha.18's "Excluded from this release").
   - Collateral lock updates: `opentelemetry-http` / `opentelemetry-proto` 0.31 → 0.32, `reqwest` 0.12 → 0.13 (transitive via `opentelemetry-otlp`), adds `tonic-types` 0.14.6 as a new transitive.
   - No code changes — the API surface used in `memvid-service/src/otel.rs` (`SpanExporter::builder().with_tonic()`, `SdkTracerProvider::builder()`, `Resource::builder_empty()`, `OpenTelemetryLayer::new(tracer)`) is forward-compatible between 0.31 and 0.32.
+
+### Fixed
+
+- api Dockerfile: stage `libgcc_s` versioned target alongside the symlink so it resolves in the runtime image (#263). The python-deps stage's `find … -name "libgcc_s.so*"` glob matched the `libgcc_s.so.1` symlink but not its versioned target `libgcc_s-14-<snapshot>.so.1` (because of the `-14-` infix). This worked by coincidence as long as `rockylinux/rockylinux:10-minimal` and `registry.access.redhat.com/ubi10/ubi-micro` shipped the same libgcc snapshot; after ubi-micro rolled forward to `libgcc-14-20251022` while rocky-10-minimal stayed on `libgcc-14-20250617`, the symlink dangled in the final image and pydantic-core / grpcio / any native extension that dynamically links libgcc_s.so.1 failed to import at container startup. Added a second glob `'libgcc_s-*.so*'` to the find loop. Same pattern that already makes `libstdc++.so*` work (the versioned filename also matches because there's no infix). When rocky-10-minimal eventually moves to RHEL 10.2 (matching ubi-micro), this fix becomes a no-op — but it also hardens against the next time the two base images drift.
 
 ### Excluded from this release
 


### PR DESCRIPTION
## Summary

Supersedes the withdrawn `0.1.0-alpha.19` tag. Same dep content as alpha.19 (PRs #260 + #261) plus the libgcc Dockerfile fix (#263). Cutting fresh as alpha.20 from current `main` HEAD avoids reusing a burned tag and breaks the race condition in release-validate's CI-run selection.

## Why alpha.19 was withdrawn

| | When | Trigger commit | Failure |
|-|-|-|-|
| 1st tag | 2026-05-21 22:38 | `caef43b` | api container `ImportError: libgcc_s.so.1` at startup |
| 2nd tag | 2026-05-22 06:48 | `cbebdf8` | release workflow `verify-signatures (ai-resume-ingest)` → `no signatures found` |

### First withdrawal — libgcc

Latent api/Dockerfile bug exposed by `registry.access.redhat.com/ubi10/ubi-micro` rolling forward to `libgcc-14-20251022` while `rockylinux/rockylinux:10-minimal` stayed on `libgcc-14-20250617`. The find loop's `libgcc_s.so*` glob matched the symlink but not its versioned target (because of the `-14-` infix), so the symlink dangled in the final image. Fixed in **#263** (one-line glob addition). NOT caused by my dep rollup — reproduced with alpha.18's exact lockfile.

### Second withdrawal — signature verification

[Workflow run 26283389287](https://github.com/schwichtgit/ai-resume/actions/runs/26283389287/job/77367256620). Two concurrent CI runs existed on `cbebdf8`:

- **26283337168** (`push` event to main when #263 merged) — built with `VERSION=dev-cbebdf8-B20260522104825`, signed digest `65f44c...`
- **26283389240** (`push` event to tag `v0.1.0-alpha.19`) — built with `VERSION=v0.1.0-alpha.19`, signed digest `ba4dff...`

Release-validate logged `##[warning]No tag-triggered CI run passed, using run 26283337168` — it raced and selected the main-push run before the tag-triggered run finished. The merge-manifests step then assembled the multi-arch manifest from the dev-versioned per-arch digests, and `verify-signatures` couldn't find a signature for `:v0.1.0-alpha.19.amd64` because that tag pointed at a digest signed under a different version tag.

Cutting alpha.20 from current `main` HEAD means there's exactly one CI run on the alpha.20 SHA (the push from this release-doc merge) before the tag is cut. No race.

## Content of alpha.20

Identical to the withdrawn alpha.19 entry plus a new **Fixed** section for #263. See CHANGELOG.md diff.

## Test plan

- [ ] CI green on the merge commit
- [ ] After merge: re-tag `v0.1.0-alpha.20` on the new `main` HEAD, push, watch the Release workflow's `verify-signatures` step pass on all four images
- [ ] If validate still selects the wrong CI run: file a follow-up to harden the validate step's tag-vs-push-run preference (e.g. require `head_branch == tag_name` AND wait for tag-event run to finish before falling back)

## Follow-ups (not in this PR)

- HIGH-severity CSAF flag on `ubi10/ubi-micro` surfaced by the Red Hat Dependency Analytics IDE plugin
- Release-validate run-selection race condition is a real workflow bug; the libgcc fix triggered it but it's latent and will recur on any future tag re-cut