### PR TITLE
test(ingest): self-orchestrate e2e .mv2 from shipped resume, gate at release

### DIFF
--- a/ingest/tests/conftest.py
+++ b/ingest/tests/conftest.py
@@ -13,7 +13,7 @@ EXAMPLE_RESUME = PROJECT_ROOT / "data" / "example_resume.md"
 
 
 @pytest.fixture(scope="session")
-def jane_mv2_base(tmp_path_factory) -> Path:
+def jane_mv2_base(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Ingest the shipped example resume (Jane Chen) into a .mv2 once per session."""
     out = tmp_path_factory.mktemp("mv2") / "jane.mv2"
     ingest_memory(input_path=EXAMPLE_RESUME, output_path=out, verbose=False)

--- a/ingest/tests/conftest.py
+++ b/ingest/tests/conftest.py
@@ -6,22 +6,30 @@ from pathlib import Path
 
 import pytest
 
+from ingest import ingest_memory
+
 PROJECT_ROOT = Path(__file__).parent.parent.parent
-SOURCE_MV2 = PROJECT_ROOT / "data" / ".memvid" / "resume.mv2"
+EXAMPLE_RESUME = PROJECT_ROOT / "data" / "example_resume.md"
+
+
+@pytest.fixture(scope="session")
+def jane_mv2_base(tmp_path_factory) -> Path:
+    """Ingest the shipped example resume (Jane Chen) into a .mv2 once per session."""
+    out = tmp_path_factory.mktemp("mv2") / "jane.mv2"
+    ingest_memory(input_path=EXAMPLE_RESUME, output_path=out, verbose=False)
+    return out
 
 
 @pytest.fixture
-def isolated_mv2(tmp_path: Path) -> Generator[str, None, None]:
-    """Copy resume.mv2 to an isolated temp path for exclusive access.
+def isolated_mv2(jane_mv2_base: Path, tmp_path: Path) -> Generator[str, None, None]:
+    """Copy the session Jane .mv2 to an isolated temp path for exclusive access.
 
     memvid-core 2.0.139+ acquires an exclusive file lock on open.
     Each test gets its own copy so tests can run in parallel without
     lock contention.
     """
-    if not SOURCE_MV2.exists():
-        pytest.skip(f"{SOURCE_MV2} not found. Run ingest first.")
     dest = tmp_path / "test.mv2"
-    shutil.copy2(SOURCE_MV2, dest)
+    shutil.copy2(jane_mv2_base, dest)
     yield str(dest)
     # Clean up any WAL files memvid creates alongside the copy
     for wal in tmp_path.glob("*.wal"):

--- a/ingest/tests/test_e2e.py
+++ b/ingest/tests/test_e2e.py
@@ -126,6 +126,7 @@ RETRIEVAL_TEST_CASES = [
 ]
 
 
+@pytest.mark.slow
 def test_memvid_retrieval(isolated_mv2: str) -> None:
     """Test that memvid retrieves expected content for each test case."""
     print("\n" + "=" * 70)
@@ -195,6 +196,7 @@ def test_memvid_retrieval(isolated_mv2: str) -> None:
     assert failed == 0, f"{failed} retrieval test(s) failed"
 
 
+@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_query_transformation_improves_retrieval(isolated_mv2: str) -> tuple[int, int]:
     """Test that query transformation improves retrieval for ambiguous queries."""
@@ -310,6 +312,7 @@ async def test_query_transformation_improves_retrieval(isolated_mv2: str) -> tup
     return passed, failed
 
 
+@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_full_rag_pipeline(isolated_mv2: str) -> tuple[int, int]:
     """Test the complete RAG pipeline produces correct answers."""

--- a/ingest/tests/test_memvid.py
+++ b/ingest/tests/test_memvid.py
@@ -8,6 +8,7 @@ Run with: uv run python test_memvid.py
 import os
 import tempfile
 
+import pytest
 import memvid_sdk
 
 
@@ -105,6 +106,7 @@ def test_create_and_query() -> None:
     print("\nTest completed successfully!")
 
 
+@pytest.mark.slow
 def test_open_existing(isolated_mv2: str) -> None:
     """Test opening an existing .mv2 file (if one exists)."""
     print("\n=== Open Existing Test ===")

--- a/ingest/tests/test_memvid_lex_diagnostics.py
+++ b/ingest/tests/test_memvid_lex_diagnostics.py
@@ -18,6 +18,7 @@ import pytest
 import memvid_sdk
 
 
+@pytest.mark.slow
 def test_index_status(isolated_mv2: str) -> None:
     """Check if indexes are enabled/disabled in the .mv2 file."""
     print("=" * 70)

--- a/scripts/test-ingest.sh
+++ b/scripts/test-ingest.sh
@@ -87,6 +87,24 @@ if [ -f "$OUTPUT_FILE" ]; then
     fi
 fi
 
+# Slow ingest e2e tests (retrieval accuracy + RAG smoke).
+# These are marked @pytest.mark.slow so they are deselected from the fast PR
+# loop; the release gate is where they run. Each self-orchestrates its own .mv2
+# by ingesting data/example_resume.md via a session fixture (no dependency on a
+# pre-existing artifact). LLM-dependent cases skip cleanly without OPENROUTER_API_KEY.
+echo ""
+log_info "Running slow ingest e2e tests (-m slow)..."
+# --no-cov: this is a retrieval-correctness subset, not a coverage run; the
+# 85% line-coverage gate belongs to the full `-m "not slow"` suite, and a
+# slow-only selection cannot reach it.
+if (cd "$PROJECT_ROOT/ingest" && uv run --extra test pytest -m slow -v --tb=short --no-cov); then
+    log_pass "Slow ingest e2e tests passed"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    log_fail "Slow ingest e2e tests failed"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
 # Summary
 TOTAL=$((TESTS_PASSED + TESTS_FAILED))
 echo ""


### PR DESCRIPTION
## Summary

Make the ingest e2e tests own their own data instead of depending on a developer-generated artifact, and run them at release time.

### Problem

`ingest/tests/conftest.py` pointed `isolated_mv2` at `data/.memvid/resume.mv2` — a file produced out-of-band by whoever last ran `ingest.py` locally. The retrieval test cases are written for the shipped **Jane Chen** persona (`data/example_resume.md`), so the suite only passed if a developer happened to have ingested Jane locally; otherwise it skipped (no file) or failed against the wrong persona (e.g. a real resume).

### Fix

The test harness now orchestrates the full pipeline itself:

- New session-scoped `jane_mv2_base` fixture ingests the shipped `data/example_resume.md` via `ingest_memory()` into a temp `.mv2` (once per session).
- `isolated_mv2` copies that per-test (preserving the exclusive-lock isolation the copy existed for). Signature unchanged — no test-body edits.
- Removed the `SOURCE_MV2` filesystem dependency and the "run ingest first" skip.

### Slow / opt-in

The five `.mv2`-consuming tests are marked `@pytest.mark.slow` (model load + ingest), so they're deselected from the fast PR loop (`-m "not slow"`). To keep them gating, `scripts/test-ingest.sh` (release-gate Phase 3) now runs `-m slow` — so `task release-gate` validates retrieval accuracy. `--no-cov` there because the 85% line-coverage gate belongs to the full `not slow` suite; a slow-only subset can't reach it.

## Verification

- `-m "not slow"`: 77 passed, 14 deselected; the session ingest fixture provably does not fire (0 setups) — fast loop unaffected.
- `-m slow` (via the release-gate path): **14 passed**, 0 failed, retrieval cases all green against the self-generated Jane `.mv2`. LLM-dependent cases skip cleanly without `OPENROUTER_API_KEY`.

Unrelated to the Dependabot rollup (#273); separate branch by design.
