### PR TITLE
build(taskfile): fix prettier/markdown lint race with npm ci

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -115,11 +115,19 @@ tasks:
 
   lint:prettier:
     desc: Run prettier --check against the repo (matches CI ci-base/prettier)
+    # deps on frontend:setup so the `npm ci` that installs prettier completes
+    # before this reads node_modules. Without it, `task lint` schedules setup
+    # (which does `rm -rf node_modules`) concurrently with this task, and
+    # prettier dies mid-run with ERR_MODULE_NOT_FOUND on its own plugins.
+    deps: [frontend:setup]
     cmds:
       - npx --prefix frontend prettier --check .
 
   lint:markdown:
     desc: Run markdownlint-cli2 (matches CI ci-base/markdownlint)
+    # See lint:prettier — same npm-ci race; markdownlint-cli2 also lives in
+    # frontend/node_modules.
+    deps: [frontend:setup]
     cmds:
       - npx --prefix frontend markdownlint-cli2 '**/*.md'
 


### PR DESCRIPTION
## Problem

`task lint` runs its deps in parallel. `lint:prettier` and `lint:markdown` invoke `npx --prefix frontend ...` but did not depend on `frontend:setup`, which runs `npm ci` (and thus `rm -rf node_modules`). When node_modules was stale (e.g. after a branch switch that changes `frontend/package-lock.json`), go-task scheduled the `npm ci` concurrently with the lint tasks, and prettier/markdownlint died mid-run with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../frontend/node_modules/prettier/plugins/markdown.mjs'
```

This intermittently failed the local `verify-quality` Stop hook even though the files were correctly formatted.

## Fix

Declare `deps: [frontend:setup]` on `lint:prettier` and `lint:markdown`. go-task dedups `frontend:setup` across all consumers (`frontend:lint`, `frontend:test`, and now these), so the install completes once before any task reads node_modules.

## Verification

- `task lint:prettier` → setup runs first, then 'All matched files use Prettier code style!'
- `task lint:markdown` → setup runs first, then '0 error(s)'