### PR TITLE
build(ci): upgrade Node.js pin from 22 to 26

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '26'
       - run: npm install --prefix frontend
       - run: npx --prefix frontend prettier --check .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
   id-token: write
 
 env:
-  NODE_VERSION: '22'
+  NODE_VERSION: '26'
 
 jobs:
   # CPF scaffold base checks (shellcheck, markdownlint, prettier, plugin-validation)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,7 +347,7 @@ The application expects to be served at `frank-resume.schwichtenberg.us` when de
 ### Container Architecture
 
 - **Frontend base**: alpine:3.23 with OpenResty (runs as nginx user)
-- **Frontend build stage**: node:24-trixie-slim for npm build
+- **Frontend build stage**: node:26.2.0-trixie-slim for npm build
 - **API base**: ubi10/ubi-micro runtime, rockylinux:10-minimal builder (3-stage build)
 - **Ingest base**: ubi10/ubi-micro runtime, rockylinux:10-minimal builder (3-stage build)
 - **Memvid base**: gcr.io/distroless/cc-debian13:nonroot (runs as nonroot user)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full system design, dat
 
 | Tool    | Minimum | Required For                         |
 | ------- | ------- | ------------------------------------ |
-| Node.js | 22.14.0 | Frontend build and dev server        |
+| Node.js | 26.2.0  | Frontend build and dev server        |
 | uv      | 0.9.0   | Python package management            |
 | go-task | 3.48.0  | Build orchestration (`task` CLI)     |
 | Rust    | 1.93.0  | memvid-service only                  |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -11,8 +11,8 @@ All dependencies are checked by `task deps`. Three tiers:
 
 | Tool    | Minimum | Install                                            |
 | ------- | ------- | -------------------------------------------------- |
-| Node.js | 22.14.0 | <https://nodejs.org/>                              |
-| npm     | 10.9.0  | Bundled with Node.js                               |
+| Node.js | 26.2.0  | <https://nodejs.org/>                              |
+| npm     | 11.0.0  | Bundled with Node.js                               |
 | uv      | 0.9.0   | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
 | go-task | 3.48.0  | <https://taskfile.dev/installation/>               |
 

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -121,8 +121,8 @@ tier_required() {
   echo "Checking required tools..."
   echo ""
 
-  check_tool "Node.js"   "node --version"    "22.14.0" "https://nodejs.org/"              || FAIL=$((FAIL + 1))
-  check_tool "npm"       "npm --version"     "10.9.0"  "(bundled with Node.js)"           || FAIL=$((FAIL + 1))
+  check_tool "Node.js"   "node --version"    "26.2.0" "https://nodejs.org/"              || FAIL=$((FAIL + 1))
+  check_tool "npm"       "npm --version"     "11.0.0"  "(bundled with Node.js)"           || FAIL=$((FAIL + 1))
   check_tool "uv"        "uv --version"      "0.9.0"   "curl -LsSf https://astral.sh/uv/install.sh | sh" || FAIL=$((FAIL + 1))
   check_tool "go-task"   "task --version"    "3.48.0"  "https://taskfile.dev/installation/" || FAIL=$((FAIL + 1))
 


### PR DESCRIPTION
## Summary

CI ran `setup-node` on Node 22 while the frontend build container is already on `node:26.2.0`. This aligns every Node pin on **Node 26**, closing that drift.

## Changes

| File | Change |
| ---- | ------ |
| `.github/workflows/ci.yml` | `NODE_VERSION: '22'` -> `'26'` (all setup-node steps reference this env) |
| `.github/workflows/ci-base.yml` | prettier job `node-version: '22'` -> `'26'` |
| `scripts/check-deps.sh` | required-tier floors: Node `22.14.0` -> `26.2.0`, npm `10.9.0` -> `11.0.0` |
| `README.md`, `docs/DEVELOPMENT.md` | prerequisites table -> Node 26.2.0 / npm 11.0.0 |
| `CLAUDE.md` | correct stale `node:24-trixie-slim` frontend build-stage reference -> `node:26.2.0` |

`frontend/Dockerfile` was already on `node:26.2.0-trixie-slim` (digest-pinned) and is unchanged.

The check-deps floors use the `.0` minimum of the supported major (matching the Node/uv/go-task convention) so they gate by major, not by exact patch. npm ships bundled with Node, so the actual npm tracks whatever Node 26 provides (11.16.0 locally).

## Test plan

- [x] `bash scripts/check-deps.sh required` -> Node 26.3.0 >= 26.2.0 PASS, npm 11.16.0 >= 11.0.0 PASS
- [x] `markdownlint-cli2` clean on README.md, docs/DEVELOPMENT.md, CLAUDE.md (0 errors)
- [x] `shellcheck scripts/check-deps.sh` clean
- [ ] CI green on this branch (setup-node resolves Node 26 in the toolcache)