### PR TITLE
ci: max out disk reclaim for amd64 ingest container build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,10 +644,12 @@ jobs:
       - uses: actions/checkout@v6
 
       # The ingest container drags in the full torch/nvidia CUDA wheel stack via
-      # sentence-transformers, which routinely exhausts the ~14 GB of free disk
-      # on the ubuntu-latest amd64 runner during `uv sync`. Reclaim ~30 GB by
-      # purging preinstalled toolchains we do not need here. Arm runner has
-      # more headroom and skips this step. Tracked: alpha.18 post-mortem.
+      # sentence-transformers (~5-6 GB unpacked), which exhausts the ~14 GB of
+      # free disk on the ubuntu-latest amd64 runner while podman stores the
+      # `.venv` layer blob under /var/tmp. Reclaim as much as possible by purging
+      # preinstalled toolchains, large apt packages, and the swapfile -- none are
+      # needed for a container build. Arm runner has more headroom and skips this
+      # step. Tracked: alpha.18 post-mortem; reclaim maxed in alpha.23.
       - name: Free disk space on amd64 ingest runner
         if: matrix.image == 'ingest' && matrix.platform == 'amd64'
         uses: jlumbroso/free-disk-space@v1.3.1
@@ -656,8 +658,8 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: false
-          swap-storage: false
+          large-packages: true
+          swap-storage: true
 
       - name: Install cosign
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))


### PR DESCRIPTION
## Problem
The `container-build (ingest, amd64)` job intermittently fails with `no space left on device` while podman stores the ingest `.venv` layer blob (torch + ~3 GB nvidia CUDA wheels, ~5-6 GB unpacked) under `/var/tmp` on the runner's ~14 GB root volume. Most recent occurrence: run 27585394200 on #327 (passed only on retry).

## Change
The existing `jlumbroso/free-disk-space` step ran with `large-packages: false` and `swap-storage: false`. Enable both:
- `large-packages: true` — purges large preinstalled apt packages (~3-5 GB)
- `swap-storage: true` — removes the 4 GB swapfile

Neither is needed for a container build. This reclaims roughly **8-10 GB more** on the root volume, zero dependency risk, one-step change.

## Scope / alternatives
This is the low-risk **stopgap** chosen over relocating podman storage to `/mnt` (works but needs CI tuning) and over the **CPU-only torch pin** (the durable image-size fix — drops the nvidia stack entirely — tracked as a separate follow-up). If the disk-out recurs even with max reclaim, that confirms the torch pin is required.