### PR TITLE
build(deps): bump tower-http 0.6.11 -> 0.7.0 in memvid-service

### DIFF
--- a/memvid-service/Cargo.lock
+++ b/memvid-service/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
  "tonic-prost",
  "tonic-prost-build",
  "tower",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -2448,7 +2448,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3332,8 +3332,24 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
  "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "percent-encoding",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/memvid-service/Cargo.toml
+++ b/memvid-service/Cargo.toml
@@ -10,7 +10,7 @@ description = "Rust-based memvid retrieval service for AI Resume"
 axum = { version = "0.8", features = ["macros"] }
 tokio = { version = "1", features = ["full"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["trace", "cors"] }
+tower-http = { version = "0.7", features = ["trace", "cors"] }
 
 # Memvid SDK
 memvid-core = { version = "2.0.140", features = ["lex"] }


### PR DESCRIPTION
Cargo 0.x minor = semver-breaking, so verified individually rather than rolled up.

## Verification (memvid-service)
- `cargo build` — clean
- `cargo clippy --all-targets` — clean
- `cargo test` — **27 passed, 0 failed**

tower-http is declared with the `trace`+`cors` features for the axum middleware layers; 0.7.0 compiles with no source changes.

Closes #333