### PR TITLE
ci: pin Trivy scanner to v0.71.2 in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Run Trivy vulnerability scanner (SARIF)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
+          version: 'v0.71.2'
           image-ref: '${{ matrix.image }}:scan'
           format: 'sarif'
           output: 'trivy-results.sarif'
@@ -54,6 +55,7 @@ jobs:
           TRIVY_SEVERITY: CRITICAL,HIGH
           TRIVY_IGNORE_UNFIXED: 'true'
         with:
+          version: 'v0.71.2'
           image-ref: '${{ matrix.image }}:scan'
           format: 'table'
           exit-code: '1'


### PR DESCRIPTION
Both `aquasecurity/trivy-action@v0.36.0` steps (SARIF scan + CRITICAL/HIGH gate) relied on the action's bundled default trivy binary (effectively 0.70.0). Pin `version: 'v0.71.2'` on both for deterministic scans against the current vuln DB.

The `trivy-action` wrapper stays at `@v0.36.0` — that's bumped independently by Dependabot's github-actions ecosystem; this only pins the trivy *binary* it installs.

## Verification
- YAML validated.
- Both steps now carry `version: 'v0.71.2'`.