### PR TITLE
build(task): whole-SBOM audit target + weekly CI audit job

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -60,3 +60,49 @@ jobs:
           format: 'table'
           exit-code: '1'
           trivyignores: '.trivyignore'
+
+  # Whole-SBOM dependency audit across all ecosystems (npm, pip, cargo) via
+  # `task audit`. Complements container-scan: this catches newly-disclosed
+  # advisories against already-pinned deps -- the case Dependabot misses
+  # (it only fires on dep *changes*), e.g. the msgpack/undici advisories that
+  # surfaced against unchanged lockfiles. Fails the run on any unsuppressed
+  # finding; suppressions live in per-service .pip-audit-ignore / .trivyignore.
+  dependency-audit:
+    name: Dependency vulnerability audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install go-task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '26'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Setup Rust (provides cargo for `cargo audit`)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: Install frontend deps (npm audit needs the lockfile resolved)
+        run: cd frontend && npm ci
+
+      - name: Run whole-SBOM dependency audit
+        run: task audit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ task setup           # Bootstrap full dev environment
 task deps            # Check tool dependencies
 task lint            # Lint all services
 task test            # Test all services
+task audit           # Whole-SBOM vuln sweep (npm, pip-audit, cargo audit)
 task build           # Build all services
 task check           # Full quality sweep (lint + typecheck + test + build)
 task ci              # Reproduce CI pipeline locally

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -145,9 +145,13 @@ tasks:
         ingest:test:coverage,
       ]
 
-  build:
-    desc: Build all services
-    deps: [frontend:build, memvid:build:release]
+  audit:
+    desc: Whole-SBOM vulnerability sweep across all ecosystems (npm, pip, cargo)
+    # Native per-ecosystem scanners against each lockfile / synced venv:
+    # frontend npm audit, api+ingest pip-audit (env mode), memvid cargo audit.
+    # Fails if any ecosystem reports a known vulnerability. Trivy container
+    # scanning is handled separately by the security.yml workflow.
+    deps: [frontend:audit, api:audit, ingest:audit, memvid:audit]
 
   check:
     desc: Full local quality sweep (lint + typecheck + test + build)

--- a/api-service/Taskfile.yml
+++ b/api-service/Taskfile.yml
@@ -43,11 +43,16 @@ tasks:
     # Env-mode audit of the synced venv -- avoids pip-audit's requirements-file
     # path, whose ephemeral-venv ensurepip SIGABRTs on uv-managed standalone
     # Python. --all-extras covers dev/sbom deps; --skip-editable drops the local
-    # project. Exits non-zero on any finding.
+    # project. Suppressions (if any) live in .pip-audit-ignore -- same file-based
+    # convention as ingest; the reader is identical so adding a suppression here
+    # is just one line in that file. No file today => no advisory suppressed.
     deps: [setup]
     cmds:
       - uv sync --all-extras
-      - '{{.UV_RUN}} --with pip-audit pip-audit --skip-editable'
+      - >-
+        {{.UV_RUN}} --with pip-audit pip-audit --skip-editable
+        $(grep -vhE '^[[:space:]]*#|^[[:space:]]*$' .pip-audit-ignore 2>/dev/null
+        | sed 's/^/--ignore-vuln /' | tr '\n' ' ')
 
   format:
     desc: Format with ruff

--- a/api-service/Taskfile.yml
+++ b/api-service/Taskfile.yml
@@ -38,6 +38,17 @@ tasks:
     cmds:
       - '{{.UV_RUN}} mypy .'
 
+  audit:
+    desc: Scan installed deps for known vulnerabilities (pip-audit, env mode)
+    # Env-mode audit of the synced venv -- avoids pip-audit's requirements-file
+    # path, whose ephemeral-venv ensurepip SIGABRTs on uv-managed standalone
+    # Python. --all-extras covers dev/sbom deps; --skip-editable drops the local
+    # project. Exits non-zero on any finding.
+    deps: [setup]
+    cmds:
+      - uv sync --all-extras
+      - '{{.UV_RUN}} --with pip-audit pip-audit --skip-editable'
+
   format:
     desc: Format with ruff
     deps: [setup]

--- a/frontend/Taskfile.yml
+++ b/frontend/Taskfile.yml
@@ -34,6 +34,13 @@ tasks:
     cmds:
       - npx tsc --noEmit
 
+  audit:
+    desc: Scan npm dependencies for known vulnerabilities (lockfile)
+    # Reads package-lock.json directly; no node_modules required. Exits
+    # non-zero on any advisory at or above the level.
+    cmds:
+      - npm audit --audit-level=low
+
   test:
     desc: Run Vitest
     deps: [setup]

--- a/ingest/.pip-audit-ignore
+++ b/ingest/.pip-audit-ignore
@@ -1,0 +1,10 @@
+# pip-audit ignore list for `task ingest:audit` (and task audit).
+# One advisory ID per line (GHSA / PYSEC / CVE). Blank lines and lines
+# starting with `#` are ignored. Keep an inline reason for every entry so
+# the suppression is auditable -- mirrors the .trivyignore convention.
+#
+# torch: no upstream fix available; ingest runs CPU embedding only.
+# Also tracked as GitHub code-scanning alert #550. Drop these when a fixed
+# torch release ships.
+PYSEC-2026-139
+CVE-2025-3000

--- a/ingest/Taskfile.yml
+++ b/ingest/Taskfile.yml
@@ -33,6 +33,21 @@ tasks:
     cmds:
       - '{{.UV_RUN}} mypy .'
 
+  audit:
+    desc: Scan installed deps for known vulnerabilities (pip-audit, env mode)
+    # See api-service audit -- env-mode pip-audit sidesteps the uv standalone
+    # Python ensurepip crash. Suppressed advisories are listed (with reasons) in
+    # .pip-audit-ignore -- file-based to mirror .trivyignore. Comments/blanks are
+    # stripped and the rest become --ignore-vuln flags. Any advisory NOT in that
+    # file still fails the task, so this stays a meaningful gate.
+    deps: [setup]
+    cmds:
+      - uv sync --all-extras
+      - >-
+        {{.UV_RUN}} --with pip-audit pip-audit --skip-editable
+        $(grep -vhE '^[[:space:]]*#|^[[:space:]]*$' .pip-audit-ignore 2>/dev/null
+        | sed 's/^/--ignore-vuln /' | tr '\n' ' ')
+
   format:
     desc: Format with ruff
     deps: [setup]

--- a/memvid-service/Taskfile.yml
+++ b/memvid-service/Taskfile.yml
@@ -53,6 +53,14 @@ tasks:
     cmds:
       - cargo tarpaulin --config tarpaulin-unit.toml
 
+  audit:
+    desc: Scan Rust dependencies for RUSTSEC advisories (Cargo.lock)
+    preconditions:
+      - sh: command -v cargo-audit
+        msg: 'cargo-audit not found. Install: cargo install --locked cargo-audit'
+    cmds:
+      - cargo audit
+
   dev:
     desc: Run memvid service
     cmds:

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -155,6 +155,7 @@ tier_optional() {
   check_tool_info "markdownlint-cli2" "markdownlint-cli2 --help"   "npm install -g markdownlint-cli2"
   check_tool_info "shellcheck"        "shellcheck --version"        "https://github.com/koalaman/shellcheck#installing"
   check_tool_info "cargo-tarpaulin"   "cargo-tarpaulin --version"   "cargo install cargo-tarpaulin"
+  check_tool_info "cargo-audit"       "cargo-audit --version"       "cargo install --locked cargo-audit"
 
   echo ""
   echo "Optional tool check complete (informational only)."


### PR DESCRIPTION
Adds `task audit` — a one-command, whole-SBOM vulnerability sweep across every ecosystem — and wires it into CI as a weekly scheduled job. Operationalizes the "we own the whole dependency tree, declared or transitive" stance.

## Local: `task audit`
Native per-ecosystem scanners, each against its lockfile / synced venv; fails if any reports a known vulnerability.
- **`frontend:audit`** — `npm audit --audit-level=low`
- **`api:audit` / `ingest:audit`** — `pip-audit` in **environment mode** (`uv run --with pip-audit pip-audit --skip-editable`), which sidesteps the uv-standalone-Python `ensurepip` SIGABRT that makes the requirements-file path unusable locally
- **`memvid:audit`** — `cargo audit`, gated by a precondition that prints an install hint if cargo-audit is absent (mirrors the `test:coverage`/cargo-tarpaulin pattern). Note: a failed precondition **hard-fails** the task with that message — intentional, so a green audit never silently skips an ecosystem.

## CI: weekly `dependency-audit` job (security.yml)
Runs `task audit` on the existing weekly schedule (Mon 06:00 UTC) + workflow_dispatch. **Complements container-scan**: catches newly-disclosed advisories against *already-pinned* deps — the gap Dependabot misses since it only fires on dep *changes* (exactly how the msgpack HIGH and undici advisories surfaced against unchanged lockfiles this cycle). Installs go-task, uv, Node 26, a Rust toolchain + cargo-audit.

## File-based suppressions (mirrors .trivyignore)
`ingest/.pip-audit-ignore` lists advisory IDs (one per line, `#` comments + inline reasons); the task strips them into `--ignore-vuln` flags. Seeded with the two torch CVEs (PYSEC-2026-139, CVE-2025-3000) that have no upstream fix (also code-scanning #550). `api:audit` uses the **identical reader** so a future suppression there is one line in `api-service/.pip-audit-ignore` — uniform convention, no empty files. Any advisory *not* in a file still fails the gate.

## Verification
- `task audit` exits **0** on current main: frontend 0, api 0, ingest 0 (+2 ignored), memvid 0 vulns.
- Deleting `.pip-audit-ignore` makes the torch CVEs reappear and the task fail — gate is real.
- go-task precondition semantics verified (failed precondition → task failure, not skip).
- All 5 Taskfiles + security.yml parse.