### PR TITLE
fix(observability): scrape memvid metrics on 9090, not the gRPC port

### DIFF
--- a/deployment/observability/prometheus.yml
+++ b/deployment/observability/prometheus.yml
@@ -12,9 +12,10 @@ scrape_configs:
   - job_name: memvid-service
     static_configs:
       - targets:
-          # Replace with actual memvid-service host:port
-          # e.g., "memvid-service:50051"
-          - 'host.containers.internal:50051'
+          # memvid metrics are on port 9090 (METRICS_PORT, default 9090);
+          # 50051 is the gRPC port and does not serve /metrics.
+          # e.g., "memvid-service:9090"
+          - 'host.containers.internal:9090'
 
   - job_name: tempo-metrics
     static_configs:


### PR DESCRIPTION
## Bug
Production `deployment/observability/prometheus.yml` scrapes memvid-service on `host.containers.internal:50051` — the **gRPC** port, which does not serve `/metrics`. So prod memvid metrics were silently never collected.

## Fix
memvid exposes Prometheus metrics on `METRICS_PORT` (default **9090**, per `memvid-service/src/config.rs`). The dev config (`deployment/prometheus.dev.yml`) already uses `:9090` correctly. This aligns prod to `:9090`.

Found during the docs-currency audit (#352). One-line config fix, kept separate from the docs PR.