### PR TITLE
ci: name the CI workflow 'CI' (was 'I')

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: I
+name: CI
 
 on:
   push:


### PR DESCRIPTION
The main CI workflow's `name:` was `I` — a typo that rendered as a bare **I** in the Actions tab and PR check list. Renamed to **CI**.

Job names (including the branch-protection-required `summary`) are unchanged, so required status checks still match.