### PR TITLE
ci: inline podman login, drop redhat-actions/podman-login@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -782,11 +782,7 @@ jobs:
 
       - name: Login to ghcr.io
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
-        uses: redhat-actions/podman-login@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Push arch-specific image
         id: push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,11 +159,7 @@ jobs:
         uses: sigstore/cosign-installer@v3
 
       - name: Login to ghcr.io
-        uses: redhat-actions/podman-login@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Download CI digest artifacts
         env:
@@ -267,11 +263,7 @@ jobs:
         uses: sigstore/cosign-installer@v3
 
       - name: Login to ghcr.io
-        uses: redhat-actions/podman-login@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Verify arch image signatures (CI-signed)
         run: |


### PR DESCRIPTION
## Why
The Release run surfaced: *"Node.js 20 is deprecated ... redhat-actions/podman-login@v1 ... forced to run on Node.js 24."*

`redhat-actions/podman-login@v1` — and its latest release **v1.7** — still declare `runs.using: node20`. The maintainer's node24 fix is committed to their `main` (2026-04-18) but **never released as a tag**, so there's nothing to bump to. And "node26" isn't an option — the GitHub Actions runtime tops out at **node24**.

## Fix
All three usages do nothing but log into ghcr.io with `GITHUB_TOKEN`, so the action is replaced with an inline step:

```yaml
- name: Login to ghcr.io
  run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
```

(ci.yml ×1, release.yml ×2.) podman is already used everywhere in the pipeline; `podman login` writes the same `auth.json` the existing `podman push` / `skopeo` steps read, so behavior is unchanged. Shell steps have **no node runtime**, so this kills the deprecation permanently *and* drops a third-party action dependency. `--password-stdin` keeps the token out of `argv`.

podman-login was the only node20-laggard action in the workflows.