### PR TITLE
fix(ci): authenticate cosign to ghcr.io for attest/sign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -782,7 +782,9 @@ jobs:
 
       - name: Login to ghcr.io
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "${{ secrets.GITHUB_TOKEN }}" | cosign login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Push arch-specific image
         id: push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,9 @@ jobs:
         uses: sigstore/cosign-installer@v3
 
       - name: Login to ghcr.io
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "${{ secrets.GITHUB_TOKEN }}" | cosign login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Download CI digest artifacts
         env:
@@ -263,7 +265,9 @@ jobs:
         uses: sigstore/cosign-installer@v3
 
       - name: Login to ghcr.io
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "${{ secrets.GITHUB_TOKEN }}" | cosign login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Verify arch image signatures (CI-signed)
         run: |


### PR DESCRIPTION
## Bug
Main CI is red: `container-build (frontend, amd64)` fails at **Attest SBOM** with `UNAUTHORIZED: User cannot be authenticated with the token provided` ([run](https://github.com/schwichtgit/ai-resume/actions/runs/28372632850/job/84054056051)). `podman push` succeeds but the cosign registry write fails.

## Root cause — regression from #356
#356 replaced `redhat-actions/podman-login@v1` with a bare `podman login`. That authenticates **podman** (for push) but not **cosign**: cosign uses go-containerregistry's docker-config keychain, not podman's `containers/auth.json`. The old action provided creds cosign could read; the bare login does not.

It went unnoticed because **#356's own CI run never ran `container-build`** — #356 only changed workflow files, which aren't in the `containers` paths-filter, so the job was skipped. The first container-build since #356 was the #366 rollup (changed `frontend/`), which is where it surfaced.

## Fix
Add `cosign login ghcr.io --password-stdin` alongside the `podman login` at all three sign sites:
- `ci.yml` container-build (attest + sign)
- `release.yml` merge-manifests (sign manifest list) and verify-signatures (verify, against potentially-private packages)

`cosign-installer` runs before each login. The skopeo-only login in `publish-tags` is unchanged (skopeo reads podman's auth).