### PR TITLE
docs: release 0.1.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-beta.2] - 2026-06-29
+
+Stabilization release: dependency currency and CI signing fixes. No new
+product features.
+
+### Changed
+
+- Dependency currency rollup consolidating 9 Dependabot PRs (#366)
+  - **api-service (pip)**: OpenTelemetry core `opentelemetry-api`/`-sdk`/`-exporter-otlp` `>=1.42.1` → `>=1.43.0` and `-instrumentation-fastapi` `>=0.63b1` → `>=0.64b0` (bumped together to keep the otel stack aligned); `prometheus-fastapi-instrumentator` `>=8.0.0` → `>=8.0.2`; `ruff` `>=0.15.18` → `>=0.15.20` (dev).
+  - **frontend (npm minor-and-patch group, 10 updates)**: `recharts` 3.9.0, `eslint` 10.6.0, `prettier` 3.9.1, `typescript-eslint` 8.62.0, `vite` 8.1.0, `@tanstack/react-query`, `@playwright/test`, `@types/node`, `@vitejs/plugin-react`, `globals`. Lock regenerated from `main` to preserve the prior undici/brace-expansion security fixes; `npm audit` clean.
+  - **frontend (docker)**: `node` `26.3.1-trixie-slim` → `26.4.0`.
+  - **memvid-service (cargo)**: `anyhow` `1.0.102` → `1.0.103`.
+  - **github_actions**: `actions/cache` `v5` → `v6`.
+
+### Fixed
+
+- CI container registry login (#356, #367). Replaced the deprecated `redhat-actions/podman-login@v1` (declares Node 20, which GitHub Actions is sunsetting) with an inline `podman login` (#356), then added an inline `cosign login` alongside it (#367) -- the bare `podman login` authenticated podman for image push but not cosign (which uses go-containerregistry's docker-config keychain, not podman's `auth.json`), so `cosign attest`/`sign` failed with `UNAUTHORIZED`. Both now authenticate to ghcr.io via `GITHUB_TOKEN` at all sign sites in `ci.yml` and `release.yml`.
+- frontend `Dockerfile` cleanups (#369): corrected the stale builder base-image comment (`node 26.3.0` -> `26.4.0`) left by the #366 bump, and silenced hadolint DL3018 with a rationale (Alpine's rolling repo makes apk version pins break on refresh; `apk upgrade --no-cache` + the digest-pinned base already control the patch level).
+
 ## [0.1.0-beta.1] - 2026-06-20
 
 First **beta**. The feature set is complete; this line is bug-fix and
@@ -579,7 +598,8 @@ documentation overhaul. No new product features since alpha.23.
 - Container images hardened with distroless runtime and SBOM
 - Base image upgrades to address known CVEs
 
-[Unreleased]: https://github.com/schwichtgit/ai-resume/compare/v0.1.0-beta.1...HEAD
+[Unreleased]: https://github.com/schwichtgit/ai-resume/compare/v0.1.0-beta.2...HEAD
+[0.1.0-beta.2]: https://github.com/schwichtgit/ai-resume/compare/v0.1.0-beta.1...v0.1.0-beta.2
 [0.1.0-beta.1]: https://github.com/schwichtgit/ai-resume/compare/v0.1.0-alpha.23...v0.1.0-beta.1
 [0.1.0-alpha.23]: https://github.com/schwichtgit/ai-resume/compare/v0.1.0-alpha.22...v0.1.0-alpha.23
 [0.1.0-alpha.22]: https://github.com/schwichtgit/ai-resume/compare/v0.1.0-alpha.21...v0.1.0-alpha.22


### PR DESCRIPTION
Cuts **0.1.0-beta.2** — a stabilization release: dependency currency plus CI signing fixes. No new product features. CHANGELOG-only (the sole version source); markdownlint clean.

## Since beta.1
- **Changed** — 9-PR Dependabot rollup (#366): OpenTelemetry core 1.43.0 / instrumentation 0.64b0, prometheus-fastapi-instrumentator 8.0.2, ruff 0.15.20; frontend npm group (10 updates incl. vite 8.1, prettier 3.9.1, eslint 10.6); node 26.4.0; anyhow 1.0.103; actions/cache v6.
- **Fixed** — CI container registry login (#356, #367): dropped the Node 20-deprecated `redhat-actions/podman-login`, inlined `podman login`, and added `cosign login` so `attest`/`sign` authenticate to ghcr.io. Plus frontend `Dockerfile` cleanups (#369): corrected the stale builder base-image comment and silenced hadolint DL3018 with a rationale.

## Signing pipeline validated
The cosign fix (#367) is confirmed working. The post-#369 push to `main` ran `container-build` through the full sign path on all four images — `Push` / `Attest SBOM` / `Sign image` all **success** (run 28384198645). So the Release workflow (same fix in `release.yml`) will sign cleanly; tagging `v0.1.0-beta.2` is safe.

## After merge
Tag `v0.1.0-beta.2` (annotated, `Release 0.1.0-beta.2`) to trigger the Release workflow's multi-arch build / sign / publish + GitHub Release.