### PR TITLE
test(ci): validate container signing pipeline

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,7 @@ ARG BUILD_COMMIT=unknown
 # =============================================================================
 # Stage 1: Build React application
 # =============================================================================
-# node 26.3.0-trixie-slim, pinned 2026-06-07
+# node 26.4.0-trixie-slim, pinned 2026-06-29
 FROM node:26.4.0-trixie-slim@sha256:a1d9d671994fc2d26e297ac56b4b1522a8bc7fa71c43b14cd1b1fe6c5116f7dc AS builder
 
 WORKDIR /app

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -46,6 +46,10 @@ FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6ee
 # OpenResty bundles lua-resty-dns, lua-resty-core, cjson, and LuaJIT.
 # lua-resty-http is installed via opm (not apk) to avoid the Alpine
 # nginx 1.28 / openresty nginx 1.27 package conflict.
+# DL3018: don't pin apk versions -- Alpine's rolling repo rotates exact
+# versions out (a pin breaks the build on the next refresh); the digest-pinned
+# base plus `apk upgrade --no-cache` already fix the patch level.
+# hadolint ignore=DL3018
 RUN apk upgrade --no-cache && \
     apk add --no-cache openresty curl && \
     curl -fsSL -o /usr/lib/nginx/lualib/resty/http.lua \


### PR DESCRIPTION
## Purpose
Validate the cosign registry-auth fix (#367), which **has not run a real container-build yet** — main's last build (#366) is red, and #367 was a workflow-only change so its CI skipped `container-build`. Touching `frontend/Dockerfile` flips the `changes` paths-filter `containers` to true, triggering the job.

## What validates where
- **This PR run**: `container-build` runs **build + smoke tests** for all images. The push/attest/`cosign attest`/`cosign sign` steps are gated to `push` events (main/tags), so **signing is NOT exercised on the PR**.
- **On merge to main**: the push to `main` runs `container-build` with the full path, including `cosign attest` + `cosign sign` — that's the real validation of #367.

So: green here = build/smoke OK; green on the post-merge main run (through `Attest SBOM` / `Sign image`) = signing fixed.

## Also a real fix
The comment above the builder `FROM` still read `node 26.3.0-trixie-slim, pinned 2026-06-07` after #366 bumped the actual image to `26.4.0` — corrected to match. So this isn't pure throwaway; the diff is keepable.