### PR TITLE
build(deps): sync ingest uv.lock to setuptools 83.0.0

### DIFF
--- a/ingest/uv.lock
+++ b/ingest/uv.lock
@@ -439,7 +439,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=7.0.0" },
     { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.15.10" },
     { name = "sentence-transformers", specifier = ">=5.4.0" },
-    { name = "setuptools", specifier = ">=80.10.2" },
+    { name = "setuptools", specifier = ">=83.0.0" },
 ]
 provides-extras = ["test", "lint"]
 
@@ -1409,11 +1409,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "80.10.2"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves Dependabot alert **#95** — `setuptools` < 83.0.0 (GHSA-h35f-9h28-mq5c / CVE-2026-59890, **medium**): MANIFEST.in exclusion bypass in sdist via Unicode NFC/NFD normalization collision on macOS APFS/HFS+.

## Root cause
Dependabot PR #413 already bumped `ingest/pyproject.toml` to `setuptools>=83.0.0` on `main`, but Dependabot's **pip** ecosystem PRs only edit `pyproject.toml` — they never regenerate `uv.lock`. The lock stayed pinned at `80.10.2` (CI runs `uv sync`, not `--locked`, so the drift passed silently), which is why alert #95 stayed open.

## Change
Lock-only: `uv lock` regenerates `ingest/uv.lock`, resolving `setuptools` 80.10.2 → 83.0.0 (4 lines). Nothing else moved.

## Verification (local)
- `ruff check` clean
- 91 passed, 91% coverage (torch 2.13 stack intact)

Dependabot alert #95 auto-dismisses once this lands on `main`.