### PR TITLE
fix(security): green the whole-SBOM dependency audit

### DIFF
--- a/api-service/pyproject.toml
+++ b/api-service/pyproject.toml
@@ -27,6 +27,9 @@ dependencies = [
     "slowapi>=0.1.10",
     "fastmcp>=3.4.4",
     "opentelemetry-exporter-otlp>=1.44.0",
+    # Transitive pin (via uvicorn/typer) to remediate PYSEC-2026-2132; drop once
+    # an upstream requirer floors click >= 8.3.3.
+    "click>=8.3.3",
 ]
 
 [project.optional-dependencies]

--- a/api-service/uv.lock
+++ b/api-service/uv.lock
@@ -51,6 +51,7 @@ version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
+    { name = "click" },
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "grpcio" },
@@ -93,6 +94,7 @@ test = [
 requires-dist = [
     { name = "black", marker = "extra == 'lint'", specifier = ">=26.5.1" },
     { name = "cachetools", specifier = ">=7.1.4" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "fastapi", specifier = ">=0.139.2" },
     { name = "fastmcp", specifier = ">=3.4.4" },
     { name = "grpcio", specifier = ">=1.82.1" },
@@ -335,14 +337,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.0"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]

--- a/memvid-service/.cargo/audit.toml
+++ b/memvid-service/.cargo/audit.toml
@@ -1,0 +1,23 @@
+# cargo-audit configuration for ai-resume-memvid.
+#
+# Suppressions below are transitive advisories that CANNOT be fixed downstream:
+# they are pinned by memvid-core 2.0.140 (latest published, 2026-05-27), which
+# caps lopdf ^0.39, quick-xml ^0.31, calamine ^0.22, and pdf-extract ^0.10 --
+# all below their patched releases. Upstream tracked at:
+#   https://github.com/memvid/memvid/issues/242
+#
+# Reachability: this service opens a pre-built, trusted .mv2 read-only and serves
+# vector/lexical search (Memvid::open_read_only + .ask). It never invokes the PDF
+# or spreadsheet/XML parsers at serving time -- document parsing happens offline
+# in the `ingest` pipeline, not on the gRPC request path with untrusted input.
+# src/ has zero references to lopdf/quick-xml/calamine/pdf-extract.
+#
+# Remove each ignore once memvid-core cuts a release that floors the patched
+# parser versions (see issue #242).
+
+[advisories]
+ignore = [
+    "RUSTSEC-2026-0187", # lopdf 0.38/0.39 stack overflow via deeply nested PDF objects; parser unreachable at serving time
+    "RUSTSEC-2026-0194", # quick-xml 0.30/0.31 quadratic run time on duplicate attribute names; parser unreachable at serving time
+    "RUSTSEC-2026-0195", # quick-xml 0.30/0.31 unbounded NsReader namespace allocation (DoS); parser unreachable at serving time
+]

--- a/memvid-service/Cargo.lock
+++ b/memvid-service/Cargo.lock
@@ -537,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1640,9 +1640,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
The scheduled `security.yml` **Dependency vulnerability audit** job (`task audit`) has failed since ~2026-06-29 on newly-disclosed advisories against pinned deps. This remediates every fixable one and document-suppresses only what's capped upstream.

## Fixed (real bumps)
| Advisory | Change |
|---|---|
| PYSEC-2026-2132 | api-service `click` 8.3.0 → **8.4.2** (transitive pin via uvicorn/typer; `uv.lock` regenerated; `pip-audit` clean) |
| RUSTSEC-2026-0204 | memvid `crossbeam-epoch` 0.9.18 → **0.9.20** |
| RUSTSEC-2026-0186 (unsound) | memvid `memmap2` 0.9.9 → **0.9.11** |

## Suppressed — documented, capped upstream
Added `memvid-service/.cargo/audit.toml` ignoring **RUSTSEC-2026-0187** (lopdf), **-0194 / -0195** (quick-xml). These are pinned by **memvid-core 2.0.140** (latest, 2026-05-27), which caps `lopdf ^0.39` / `quick-xml ^0.31` / `calamine ^0.22` / `pdf-extract ^0.10` — all below their patched releases, so no downstream bump can fix them.

**Reachability justification:** `ai-resume-memvid` opens a pre-built, trusted `.mv2` read-only and serves vector/lexical search (`Memvid::open_read_only` + `.ask`). It never invokes the PDF/XLSX parsers at serving time — document parsing happens offline in the `ingest` pipeline, and `src/` has zero references to these crates. So the DoS/overflow advisories aren't reachable with attacker-controlled input.

Upstream tracking issue filed: **memvid/memvid#242** (requesting the parser bumps). Suppressions carry a `remove once memvid-core releases` note.

## Left as visible non-failing warnings (not suppressed)
`bincode` / `ttf-parser` (unmaintained), `lru` (unsound — capped by `tantivy 0.25` at `^0.12`; fix is ≥0.16.2), `zip` (yanked). These are `warning`-tier in cargo-audit and don't fail the gate; kept visible as to-dos rather than hidden.

## Verification
- `task audit` → **exit 0** (whole-SBOM green)
- api-service: `ruff` clean, **501 passed**
- memvid-service: `clippy` clean, **all tests passed**