### PR TITLE
fix(security): migrate to react-router v8 (GHSA-qwww-vcr4-c8h2)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -55,7 +55,7 @@
         "react-dom": "^19.2.8",
         "react-hook-form": "^7.82.0",
         "react-resizable-panels": "^4.12.2",
-        "react-router-dom": "^7.18.1",
+        "react-router": "^8.3.0",
         "recharts": "^3.10.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
@@ -4472,18 +4472,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6428,41 +6421,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-style-singleton": {
@@ -6637,12 +6613,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,7 +61,7 @@
     "react-dom": "^19.2.8",
     "react-hook-form": "^7.82.0",
     "react-resizable-panels": "^4.12.2",
-    "react-router-dom": "^7.18.1",
+    "react-router": "^8.3.0",
     "recharts": "^3.10.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { Toaster } from '@/components/ui/toaster';
 import { Toaster as Sonner } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router';
 import { ThemeProvider } from 'next-themes';
 import { ProfileProvider } from '@/context/ProfileContext';
 import Index from './pages/Index';

--- a/frontend/src/components/NavLink.tsx
+++ b/frontend/src/components/NavLink.tsx
@@ -1,4 +1,4 @@
-import { NavLink as RouterNavLink, NavLinkProps } from 'react-router-dom';
+import { NavLink as RouterNavLink, NavLinkProps } from 'react-router';
 import { forwardRef } from 'react';
 import { cn } from '@/lib/utils';
 

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useEffect } from 'react';
 
 const NotFound = () => {


### PR DESCRIPTION
Resolves the **HIGH** Dependabot alert **GHSA-qwww-vcr4-c8h2** (React Router RSC Mode CSRF bypass; vulnerable `>=7.12.0 <8.3.0`).

## Why Dependabot couldn't auto-fix it
The security-update job failed with `security_update_not_possible`: `react-router-dom@7.18.1` hard-pins `react-router@7.18.1`, and there is **no patched 7.x** — the fix is `react-router` **8.3.0**. React Router v8 consolidated everything into the `react-router` package and stopped publishing `react-router-dom`, so the npm-override path isn't viable either. The fix is to drop `react-router-dom` and import from `react-router`.

## Change
- `package.json`: `react-router-dom ^7.18.1` → `react-router ^8.3.0`
- Repoint the 3 import sites — `App.tsx` (BrowserRouter/Routes/Route), `components/NavLink.tsx` (NavLink/NavLinkProps), `pages/NotFound.tsx` (useLocation) — from `react-router-dom` to `react-router`. No API changes required.
- `package-lock.json` regenerated (`react-router-dom` removed).
- Peer deps satisfied: v8 requires react ≥19.2.7; app is on 19.2.8.

## Reachability
The advisory is **RSC-mode specific**. This is a client-side `BrowserRouter` SPA with no RSC/server-action path, so it isn't reachable here — but v8 is the durable fix and clears the alert outright.

## Verification
- `tsc -b` typecheck clean
- eslint **0 errors** (10 pre-existing shadcn `react-refresh` warnings unchanged)
- **74 tests passed**, `vite build` OK
- `npm audit` → **0 vulnerabilities**