### PR TITLE
chore(lint): clear eslint warnings (ignore coverage, scope ui/ rule)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'coverage'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],
@@ -24,6 +24,16 @@ export default tseslint.config(
         { allowConstantExport: true },
       ],
       '@typescript-eslint/no-unused-vars': 'off',
+    },
+  },
+  {
+    // Vendored shadcn/ui primitives intentionally co-locate a component with
+    // its `*Variants` (cva) helper / context, which trips this Fast Refresh
+    // lint. That pattern is upstream shadcn convention and dev-only, so scope
+    // the rule off for the ui/ directory rather than churn each file.
+    files: ['src/components/ui/**/*.{ts,tsx}'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
     },
   },
 );


### PR DESCRIPTION
`npm run lint` reported 10 warnings, none actionable in source. This clears them so `eslint .` is **0 errors, 0 warnings**.

## Changes (eslint.config.js only)
- **Ignore `coverage/`** — eslint only ignored `dist`, so it linted the gitignored `coverage/lcov-report/*.js` report, producing 3× *"unused eslint-disable directive"* warnings on generated files.
- **Scope-off `react-refresh/only-export-components` for `src/components/ui/**`** — the 7 remaining warnings are vendored shadcn primitives (badge, button, form, navigation-menu, sidebar, sonner, toggle) that intentionally co-locate a component with its `*Variants` (cva) helper/context. That's upstream shadcn convention and dev-only (Fast Refresh); the rule stays enforced everywhere else.

No source or behavior changes.

## Verification
- `eslint .` → **0 errors, 0 warnings** (was 0 errors / 10 warnings)
- rule still active outside `ui/`