### PR TITLE
fix(task): add missing root build target

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -145,6 +145,13 @@ tasks:
         ingest:test:coverage,
       ]
 
+  build:
+    desc: Build all services
+    # Mirrors the CI build steps: frontend production bundle (`npm run build`)
+    # and the memvid release binary (`cargo build --release`). api-service and
+    # ingest are pure Python -- they have no compile step, so nothing to build.
+    deps: [frontend:build, memvid:build:release]
+
   audit:
     desc: Whole-SBOM vulnerability sweep across all ecosystems (npm, pip, cargo)
     # Native per-ecosystem scanners against each lockfile / synced venv:


### PR DESCRIPTION
## Problem

`task check` and `task ci` both end with `- task: build` (`Taskfile.yml:164`, `:175`), but there is no root `build` task. The only build targets are `container:build`, `frontend:build`, `memvid:build` and `memvid:build:release`.

Both aggregate targets therefore abort at their final step:

```
task: Failed to run task "ci": task: Task "build" does not exist
```

So neither `task check` nor `task ci` has ever run to completion, and the project docs list `task build # Build all services` as a working command.

## Fix

Add a root `build` that mirrors what CI actually builds:

| CI step | Task |
| --- | --- |
| `ci.yml:119` `npm run build` | `frontend:build` |
| `ci.yml:399`/`:457` `cargo build --release` | `memvid:build:release` |

api-service and ingest are pure Python — no compile step, nothing to contribute.

Uses `deps:` for parallel execution, consistent with the existing `test`, `test:coverage` and `audit` aggregate tasks.

## Verification

- `task --list` now shows `build: Build all services`
- `task build` → exit 0 (frontend bundle + memvid release binary, 3m45s cold)
- **`task check` → exit 0 end-to-end** — first time it completes: lint (shellcheck, prettier, markdownlint, ruff ×2, clippy) + typecheck (tsc, mypy ×2) + tests (frontend 74, api-service 501, ingest 77, memvid 165) + build

`task ci` additionally requires `cargo-tarpaulin` for `memvid:test:coverage`; that is an unrelated, already-documented precondition (`cargo install cargo-tarpaulin`) and not something this PR changes. With the target present, `ci` now reaches `build` once that tool is installed.
