### PR TITLE
fix(ci): switch Python Dependabot to uv ecosystem, gate lock drift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,9 @@ updates:
           - 'patch'
 
   # Python (api-service)
-  - package-ecosystem: 'pip'
+  # 'uv', not 'pip': the pip ecosystem edits pyproject.toml without
+  # regenerating uv.lock, which leaves the two out of sync (see #436).
+  - package-ecosystem: 'uv'
     directory: '/api-service'
     schedule:
       interval: 'weekly'
@@ -30,7 +32,8 @@ updates:
           - 'patch'
 
   # Python (ingest)
-  - package-ecosystem: 'pip'
+  # See api-service above: 'uv' keeps uv.lock in step with pyproject.toml.
+  - package-ecosystem: 'uv'
     directory: '/ingest'
     schedule:
       interval: 'weekly'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,11 @@ jobs:
         with:
           enable-cache: true
 
+      # Must run before `uv sync`: sync silently re-resolves a stale lock, so
+      # pyproject.toml/uv.lock drift would otherwise pass CI unnoticed.
+      - name: Verify uv.lock is in sync with pyproject.toml
+        run: uv lock --check
+
       - name: Install dependencies
         run: uv sync --extra test --extra lint
 
@@ -185,6 +190,10 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+
+      # See the api-service job: this must precede `uv sync`.
+      - name: Verify uv.lock is in sync with pyproject.toml
+        run: uv lock --check
 
       - name: Install dependencies
         run: uv sync --extra test --extra lint

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -170,10 +170,15 @@ tasks:
       - task: test
       - task: build
 
+  lock:check:
+    desc: Verify every uv.lock is in sync with its pyproject.toml (matches CI)
+    deps: [api:lock:check, ingest:lock:check]
+
   ci:
     desc: Reproduce CI pipeline locally
     cmds:
       - task: deps:required
+      - task: lock:check
       - task: lint
       - task: frontend:typecheck
       - task: api:typecheck

--- a/api-service/Taskfile.yml
+++ b/api-service/Taskfile.yml
@@ -14,6 +14,13 @@ tasks:
       - test -d {{.VENV}}
       - test -f {{.VENV}}/bin/python
 
+  lock:check:
+    desc: Verify uv.lock is in sync with pyproject.toml (matches CI)
+    # No `deps: [setup]` on purpose -- setup runs `uv sync`, which silently
+    # re-resolves a stale lock and would mask the drift this check exists for.
+    cmds:
+      - uv lock --check
+
   lint:
     desc: Run ruff lint + format check
     deps: [setup]

--- a/api-service/uv.lock
+++ b/api-service/uv.lock
@@ -115,7 +115,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.4.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=7.1.0" },
     { name = "python-multipart", specifier = ">=0.0.32" },
-    { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.16.0" },
+    { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.16.1" },
     { name = "setuptools", specifier = ">=83.0.0" },
     { name = "slowapi", specifier = ">=0.1.10" },
     { name = "starlette", specifier = ">=1.3.1" },

--- a/ingest/Taskfile.yml
+++ b/ingest/Taskfile.yml
@@ -13,6 +13,13 @@ tasks:
     status:
       - test -d {{.VENV}}
 
+  lock:check:
+    desc: Verify uv.lock is in sync with pyproject.toml (matches CI)
+    # See api-service/Taskfile.yml -- no `deps: [setup]`, since `uv sync`
+    # would re-resolve the lock and hide the drift.
+    cmds:
+      - uv lock --check
+
   lint:
     desc: Run ruff lint + format check
     deps: [setup]


### PR DESCRIPTION
## Problem

Dependabot's `pip` ecosystem understands `pyproject.toml` but not `uv.lock`, so it edits one and leaves the other behind.

#436 is the concrete case: it bumped ruff to `>=0.16.1` and **changed exactly one file** (`api-service/pyproject.toml`). After merge, `main` had:

```
pyproject.toml:  "ruff>=0.16.1"
uv.lock:         { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.16.0" }
```

`uv lock --check` fails on `main` today.

CI never noticed because the install step is `uv sync`, which **silently re-resolves a stale lock** rather than failing. The drift only surfaces locally, on whoever next runs `uv lock` — where it shows up as an unrelated stray diff in their branch.

## Fix — two layers

**1. Fix the source.** `package-ecosystem: 'pip'` → `'uv'` for `/api-service` and `/ingest`. The uv ecosystem has been GA since [March 2025](https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/) and [updates `uv.lock`](https://docs.astral.sh/uv/guides/integration/dependabot/) alongside `pyproject.toml`.

**2. Gate it anyway.** Add `uv lock --check` to the api-service and ingest CI jobs, positioned **before** `uv sync` so sync cannot mask the drift. Layer 1 alone is not enough — the uv ecosystem still has open edge cases where `uv.lock` is missed ([dependabot-core#13912](https://github.com/dependabot/dependabot-core/issues/13912)), and this also catches drift from hand-edited rollups and manual `pyproject.toml` changes.

Also:
- Regenerates `api-service/uv.lock` to clear the existing drift, so the new gate passes on merge.
- Adds `lock:check` tasks (root + both services) wired into `task ci`, so `task ci` keeps reproducing CI. Deliberately **no** `deps: [setup]` on those tasks — setup runs `uv sync`, which would re-resolve the lock and hide the very drift being checked.

## Verification

| Check | Result |
| --- | --- |
| `task lock:check` (clean tree) | **exit 0** |
| `task lock:check` with a one-line `mypy>=2.3.0`→`2.3.1` drift injected | **exit 1** — `api:lock:check` fails as intended |
| `task lock:check` after restoring | **exit 0** |
| `uv lock --check` api-service / ingest | in sync |
| `task lint:prettier` | pass |
| YAML parse: dependabot.yml, ci.yml, 3× Taskfile.yml | pass |
| `dependabot.yml` ecosystems after change | `cargo, docker, github-actions, npm, uv` |

## Merge ordering

Touches `api-service/uv.lock`, as does #445. Whichever lands second needs a trivial rebase — the resolution is just "re-run `uv lock`".
